### PR TITLE
feature/PODAAC-4721: Added support for bulk operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- **PODAAC-4721**
+  - Enhanced MetataAggregator by adding DMRPP Processor which supports bulk operation
+### Deprecated
+### Removed
+### Fixed
+### Security
+
 ## [8.0.0] - 2022-06-06
 ### Added
 - **PODAAC-4328**

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/CMRLambdaRestClient.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/CMRLambdaRestClient.java
@@ -218,7 +218,7 @@ public class CMRLambdaRestClient extends CMRRestClient {
      * @return revison-id in BigInteger
      */
     public BigInteger decodeRevisionString(String responseJson) {
-        JsonObject inputKey = new JsonParser().parse(responseJson).getAsJsonObject();
+        JsonObject inputKey =JsonParser.parseString(responseJson).getAsJsonObject();
         JsonArray granules = inputKey.getAsJsonArray("items");
         /**
          * If not items array has size not equal to 1 then either this granule has not

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/DMRPPProcessor.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/DMRPPProcessor.java
@@ -1,0 +1,38 @@
+package gov.nasa.cumulus.metadata.aggregator.processor;
+
+import com.google.gson.JsonObject;
+import com.vividsolutions.jts.io.ParseException;
+import cumulus_message_adapter.message_parser.AdapterLogger;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.file.Paths;
+
+public class DMRPPProcessor extends ProcessorBase{
+    private final String className = this.getClass().getName();
+    public String process(String input, String ummgStr, String region, String revisionId)
+            throws IOException, ParseException {
+        try {
+            String cmrBucket = System.getenv().getOrDefault("INTERNAL_BUCKET", "");
+            String cmrDir = System.getenv().getOrDefault("CMR_DIR", "");
+            AdapterLogger.LogDebug(this.className + " internal bucket: " + cmrBucket + " CMR Dir: " + cmrDir);
+            this.region = region;
+            decodeVariables(input);
+            String cmrFileName = buildCMRFileName(this.granuleId, this.executionId);
+            long cmrFileSize = uploadCMRJson(cmrBucket, cmrDir, this.collectionName, cmrFileName, ummgStr);
+            // Create the eTag for CMR file.
+            String cmrETag = s3Utils.getS3ObjectETag(this.region, cmrBucket,
+                    Paths.get(cmrDir, this.collectionName,
+                            cmrFileName).toString());
+            AdapterLogger.LogDebug(this.className + " cmr.json file size: " + cmrFileSize);
+            String output = createOutputMessage(input, cmrFileSize, cmrETag, new BigInteger(revisionId),
+                    cmrFileName,
+                    cmrBucket, cmrDir, this.collectionName);
+            return output;
+        } catch (IOException e) {
+            AdapterLogger.LogError("Footprint processor exception:" + e);
+            throw e;
+        }
+    }
+
+}

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/FootprintProcessor.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/FootprintProcessor.java
@@ -159,7 +159,7 @@ public class FootprintProcessor extends ProcessorBase{
                 .registerTypeHierarchyAdapter(List.class, new UMMGListAdapter())
                 .registerTypeHierarchyAdapter(Map.class, new UMMGMapAdapter())
                 .create();
-        JsonObject cmrJsonObj = new JsonParser().parse(cmrStr).getAsJsonObject();
+        JsonObject cmrJsonObj = JsonParser.parseString(cmrStr).getAsJsonObject();
         JsonObject spatialExtentJsonObj = cmrJsonObj.getAsJsonObject("SpatialExtent");
         SpatialExtentType spatialExtentType = null;
         if (spatialExtentJsonObj != null) {

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/ProcessorBase.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/ProcessorBase.java
@@ -19,6 +19,7 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class ProcessorBase {
     private final String className = this.getClass().getName();
@@ -130,14 +131,17 @@ public class ProcessorBase {
     }
 
     public void decodeVariables(String input) {
-        JsonObject inputJsonObj = new JsonParser().parse(input).getAsJsonObject();
+        JsonObject inputJsonObj = JsonParser.parseString(input).getAsJsonObject();
         JsonArray granules = inputJsonObj.getAsJsonArray("input");
         JsonObject granule = granules.get(0).getAsJsonObject();
 
         // Parse config values
         JsonObject config = inputJsonObj.getAsJsonObject("config");
         collectionName = config.get("collection").getAsString();
-        executionId = config.get("executionId").getAsString();
+        /** if subworkflow is triggered by bulk operation.  there will be no executionId */
+
+        executionId = config.get("executionId") != null? config.get("executionId").getAsString():
+                UUID.randomUUID().toString();
 
         granuleId = granule.get("granuleId").getAsString();
         files = granule.get("files").getAsJsonArray();

--- a/src/main/java/gov/nasa/cumulus/metadata/state/WorkflowTypeEnum.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/state/WorkflowTypeEnum.java
@@ -1,0 +1,9 @@
+package gov.nasa.cumulus.metadata.state;
+
+public enum WorkflowTypeEnum {
+    IngestWorkflow,
+    ForgeWorkflow,
+    ThumbnailImageWorkflow,
+    DMRPPWorkflow,
+    NONE
+}

--- a/src/test/java/gov/nasa/cumulus/metadata/test/MetadataAggregatorLambdaTest.java
+++ b/src/test/java/gov/nasa/cumulus/metadata/test/MetadataAggregatorLambdaTest.java
@@ -1,0 +1,40 @@
+package gov.nasa.cumulus.metadata.test;
+
+import gov.nasa.cumulus.metadata.aggregator.MetadataAggregatorLambda;
+import org.json.simple.parser.ParseException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MetadataAggregatorLambdaTest {
+    String cmrString = "";
+    String cmaString = null;
+
+    @Before
+    public void initialize() {
+        try {
+            ClassLoader classLoader = getClass().getClassLoader();
+
+            File inputCMAJsonFile = new File(classLoader.getResource("cumulus_message_input_example.json").getFile());
+            cmaString = new String(Files.readAllBytes(inputCMAJsonFile.toPath()));
+
+        } catch (IOException ioe) {
+            System.out.println("Test initialization failed: " + ioe);
+            ioe.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testGetConceptId() throws ParseException {
+        MetadataAggregatorLambda lambda = new MetadataAggregatorLambda();
+        String conceptId = lambda.getConceptId(this.cmaString);
+        assertEquals(conceptId, "G1238611022-POCUMULUS");
+    }
+
+}

--- a/src/test/resources/cumulus_message_input_example.json
+++ b/src/test/resources/cumulus_message_input_example.json
@@ -51,7 +51,7 @@
         }
       ],
       "version": "2019.0",
-      "cmrLink": "https://cmr.uat.earthdata.nasa.gov/search/granules.json?concept_id=G1238611022-POCUMULUS",
+      "cmrLink": "https://cmr.uat.earthdata.nasa.gov/search/concepts/G1238611022-POCUMULUS.umm_json",
       "cmrConceptId": "G1238611022-POCUMULUS",
       "published": true,
       "cmrMetadataFormat": "umm_json_v1_6",


### PR DESCRIPTION
Ticket: [PODAAC-4721](https://jira.jpl.nasa.gov/browse/PODAAC-4721)

### Description

MetadataAggregator enhancement to support bulk operation.
* Added DMRPPProcessor which pull latest UMMG and create cmr.json
* ImageProcessor already removed existing image link before re-append
* FootprintProcessor already removed fp geometry object before re-append

### Overview of work done

code change
eliminate obsolete API calls
create DMRPPProcessor
unit testing code

### Overview of verification done

Unit testing
Integration testing on SNDBOX.   MetadataAggregator works on 
* IngestWorkflow
* Main (IngestWorkflow) triggering subworkflows
* subworkflows triggered by bulk operation (input : single or multiple granule IDs)

#### Tested in SIT:

_Explain how you tested in SIT, if applicable_

## PR checklist:

* [x] Linted
* [x] Unit tests
* [ ] Addressed Snyk vulnerabilities
* [x] Updated changelog
* [ ] Tested in SIT
* [ ] Documentation / User-Guide Updated

_See [Pull Request Review Checklist](https://wiki.earthdata.nasa.gov/display/PCESA/Pull+Request+Review+Checklist) for pointers on reviewing this pull request_
