### PR TITLE
Feature/podaac 4713

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **PODAAC-4721**
   - Enhanced MetataAggregator by adding DMRPP Processor which supports bulk operation
+- **PODAAC-4713**
+  - fixed metadataAggregator can not extract posList to construct GPolygon issue
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -44,13 +44,13 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.12.209</version>
+      <version>1.12.276</version>
     </dependency>
     <!-- For AWS Secret Manager -->
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-secretsmanager</artifactId>
-      <version>1.12.209</version>
+      <version>1.12.276</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/IsoSmapXPath.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/IsoSmapXPath.java
@@ -22,4 +22,5 @@ public final class IsoSmapXPath extends IsoXPath {
     public static final String OrbitCalculatedSpatialDomains = BASE + "/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent[@id=\"boundingExtent\"]/gmd:geographicElement/gmd:EX_GeographicDescription[@id=\"OrbitCalculatedSpatialDomains0\"]/gmd:geographicIdentifier/gmd:MD_Identifier/gmd:code/gco:CharacterString";
 
     public static final String GRANULE_INPUT = BASE + CI_CITATION + "/gmd:title/gmx:FileName";
+    public static final String POLYGON = "/gmd:DS_Series/gmd:composedOf/gmd:DS_DataSet/gmd:has/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_BoundingPolygon/gmd:polygon/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList";
 }

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
@@ -494,6 +494,7 @@ public class MetadataFilesToEcho {
         ((IsoGranule) granule).setOrbit(xpath.evaluate(IsoSmapXPath.ORBIT, doc));
 
         ((IsoGranule) granule).setSwotTrack(xpath.evaluate(IsoSmapXPath.SWOT_TRACK, doc));
+		((IsoGranule) granule).setPolygon(xpath.evaluate(IsoSmapXPath.POLYGON, doc));
 
         Source source = new Source();
         source.setSourceShortName(xpath.evaluate(IsoSmapXPath.PLATFORM, doc));


### PR DESCRIPTION
Ticket: [PODAAC-4713](https://jira.jpl.nasa.gov/browse/PODAAC-4713)

### Description

While input smap iso.xml, the metadataAggregator output bounding box although the ios.xml provided posList
Expected to output ummg json with a GPolygon

### Overview of work done

Enhanced the code so when detecting smap iso, use XPath to extract posList positions and then constructs GPolygon

### Overview of verification done

Integration test on sndbox by
* Packaging the iso.xml into an existing collection and run through IngestWorkflow
* metadataAggregator generated corrected cmr.json which is attached : https://bugs.earthdata.nasa.gov/browse/PCESA-2582
* Please be noted that postToCmr step shows cmr validation error due to the coordinates crossing one another. Detail information also commented on PCESA-2582

#### Tested in SIT:

N/A

## PR checklist:

* [x] Linted
* [ ] Unit tests
* [x] Addressed Snyk vulnerabilities
* [x] Updated changelog
* [ ] Tested in SIT
* [ ] Documentation / User-Guide Updated

_See [Pull Request Review Checklist](https://wiki.earthdata.nasa.gov/display/PCESA/Pull+Request+Review+Checklist) for pointers on reviewing this pull request_
