### PR TITLE
feature/PODAAC-4713: UMM-G metadata missing spatial information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enhanced MetataAggregator by adding DMRPP Processor which supports bulk operation
 - **PODAAC-4713**
   - fixed metadataAggregator can not extract posList to construct GPolygon issue
+  - added logic to exclude bounding box if SMAP GPolygon is added
 
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enhanced MetataAggregator by adding DMRPP Processor which supports bulk operation
 - **PODAAC-4713**
   - fixed metadataAggregator can not extract posList to construct GPolygon issue
-  - added logic to exclude bounding box if SMAP GPolygon is added
+  - added logic to exclude bounding box if SMAP GPolygon is appearing under SpatialExtent
   - Upgrade amazon libraries
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PODAAC-4713**
   - fixed metadataAggregator can not extract posList to construct GPolygon issue
   - added logic to exclude bounding box if SMAP GPolygon is added
+  - Upgrade amazon libraries
 
 ### Deprecated
 ### Removed

--- a/pom.xml
+++ b/pom.xml
@@ -44,13 +44,13 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.12.276</version>
+      <version>1.12.285</version>
     </dependency>
     <!-- For AWS Secret Manager -->
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-secretsmanager</artifactId>
-      <version>1.12.276</version>
+      <version>1.12.285</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/IsoGranule.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/IsoGranule.java
@@ -20,6 +20,8 @@ public class IsoGranule extends UMMGranule {
     private List<String> inputGranules;
     private String PGEVersionClass;
 
+    private IsoType isoType;
+
     public IsoGranule() {
         this.identifiers = new HashMap<>();
         this.inputGranules = new ArrayList<>();
@@ -127,5 +129,13 @@ public class IsoGranule extends UMMGranule {
 
     public void setPGEVersionClass(String PGEVersionClass) {
         this.PGEVersionClass = PGEVersionClass;
+    }
+
+    public IsoType getIsoType() {
+        return isoType;
+    }
+
+    public void setIsoType(IsoType isoType) {
+        this.isoType = isoType;
     }
 }

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
@@ -283,6 +283,7 @@ public class MetadataFilesToEcho {
                 readIsoMendsMetadataFile(s3Location, doc, xpath);
             } else if (isoType == IsoType.SMAP) {
                 AdapterLogger.LogInfo("Found SMAP file");
+				((IsoGranule) this.granule).setIsoType(isoType);
                 readIsoSmapMetadataFile(s3Location, doc, xpath);
             } else {
                 AdapterLogger.LogWarning(isoType.name() + " didn't match any expected ISO type, skipping optional " +


### PR DESCRIPTION
Ticket: [PODAAC-4713](https://jira.jpl.nasa.gov/browse/PODAAC-4713)
forked from LP DAAC ticket : https://bugs.earthdata.nasa.gov/browse/PCESA-2582
### Description

SMAP collection going through LP DAAC should
1 create GPolygon of posList appears in iso.xml
2. UMMG should not include bounding box if GPolygon appeared under SpatialExtent

 #1 feature was done and merged to develop, LP DAAC integration tested in their environment and commented #2 needed to be done.   Hence, this PR. 
 
### Overview of work done

added logic
* if SMAP collection and GPolygon appeared, then do not create bounding rectangle.
* Upgraded amazon libraries

### Overview of verification done

* Unit tested SMAP iso.xml provided by LP DAAC and all is well
* Integration tested PODAAC SMAP_RSS_L2_SSS_V4 and found all is well - no damaging to the starting and ending orbit number which was added to the code logic at the time of releasing SMAP_RSS_L2_SSS_V4

#### Tested in SIT:

N/A

## PR checklist:

* [ ] Linted
* [ ] Unit tests
* [x] Addressed Snyk vulnerabilities
* [x] Updated changelog
* [ ] Tested in SIT
* [ ] Documentation / User-Guide Updated

_See [Pull Request Review Checklist](https://wiki.earthdata.nasa.gov/display/PCESA/Pull+Request+Review+Checklist) for pointers on reviewing this pull request_
