### PR TITLE
Sanitizer OPeNDAP related URL objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- **PODAAC-2796**
+  - remove all OPeNDAP URL object from RelatedUrls before doing dmrpp file generator processing
 ### Security
 
 ## [8.0.0] - 2022-06-06

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/DMRPPProcessor.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/DMRPPProcessor.java
@@ -1,18 +1,21 @@
 package gov.nasa.cumulus.metadata.aggregator.processor;
 
-import com.google.gson.JsonObject;
+import com.google.gson.*;
 import com.vividsolutions.jts.io.ParseException;
 import cumulus_message_adapter.message_parser.AdapterLogger;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.file.Paths;
+import java.util.Iterator;
 
 public class DMRPPProcessor extends ProcessorBase{
     private final String className = this.getClass().getName();
     public String process(String input, String ummgStr, String region, String revisionId)
             throws IOException, ParseException {
         try {
+            ummgStr = cleanseOPeNDAPUrl(ummgStr);
             String cmrBucket = System.getenv().getOrDefault("INTERNAL_BUCKET", "");
             String cmrDir = System.getenv().getOrDefault("CMR_DIR", "");
             AdapterLogger.LogDebug(this.className + " internal bucket: " + cmrBucket + " CMR Dir: " + cmrDir);
@@ -33,6 +36,27 @@ public class DMRPPProcessor extends ProcessorBase{
             AdapterLogger.LogError("Footprint processor exception:" + e);
             throw e;
         }
+    }
+
+    private String cleanseOPeNDAPUrl(String ummgStr) {
+        Gson gsonBuilder = getGsonBuilder();
+        JsonObject cmrJsonObj = JsonParser.parseString(ummgStr).getAsJsonObject();
+        JsonArray relatedUrls = cmrJsonObj.getAsJsonArray("RelatedUrls");
+        if (relatedUrls == null) {
+            return ummgStr;
+        }
+
+        Iterator<JsonElement> iterator = relatedUrls.iterator();
+        while(iterator.hasNext()){
+            JsonElement node = iterator.next();
+            JsonElement subTypeElement = node.getAsJsonObject().get("Subtype");
+            if (subTypeElement != null && StringUtils.equalsIgnoreCase(
+                    StringUtils.trim(subTypeElement.getAsString()), "OPENDAP DATA")) {
+                AdapterLogger.LogInfo(this.className + " found OPENDAP LINK and removing: " + node);
+                iterator.remove();
+            }
+        }
+        return gsonBuilder.toJson(cmrJsonObj);
     }
 
 }


### PR DESCRIPTION
Ticket: [PODAAC-2796](https://jira.jpl.nasa.gov/browse/PODAAC-2796)

### Description

bulk operation for DMRPP

### Overview of work done

* implement logic to remove all OPeNDAP URL objects from RelatedUrls in UMMG
* and then goes to DMRPP generator

### Overview of verification done
* Re-produce the issue on SNDBX by bulk operation MODIS_A granules and extra OPeNDAP url entries kept appending to RelatedUrls array.
* After code change, Integration tested bulk operation and there was always one OPeNDAP url appear under RelatedUrls. array
* Integration tested normal ingesting through IngestWorkflow.  Nothing is damaged.  One OPeNDAP url appears under RelatedUrls array.

#### Tested in SIT:

N/A

## PR checklist:

* [ ] Linted
* [ ] Unit tests
* [ ] Addressed Snyk vulnerabilities
* [x] Updated changelog
* [ ] Tested in SIT
* [ ] Documentation / User-Guide Updated

_See [Pull Request Review Checklist](https://wiki.earthdata.nasa.gov/display/PCESA/Pull+Request+Review+Checklist) for pointers on reviewing this pull request_
