### PR TITLE
remove BoundingRectangles if GPolygon appears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **PODAAC-2796**
   - remove all OPeNDAP URL object from RelatedUrls before doing dmrpp file generator processing
+- **PODAAC-4832**
+  - remove BoundingRectangles structure from SpatialExtent if GPolygon appears
 ### Security
 
 ## [8.0.0] - 2022-06-06

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/FootprintProcessor.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/FootprintProcessor.java
@@ -205,10 +205,9 @@ public class FootprintProcessor extends ProcessorBase{
         }
         if (lineTypes.size() > 0) geometryType.setLines(lineTypes);
         if (gPolygonTypes.size() > 0) geometryType.setGPolygons(gPolygonTypes);
-
+        // Remove the BoundingRectangles if Footprint appeared
         spatialExtentType = removeBBX(spatialExtentType);
         String spatialExtentStr = gsonBuilder.toJson(spatialExtentType);
-        //TODO : This area actually output both footprint/GPolygon and BoundingRectangle
         AdapterLogger.LogInfo(this.className + " SpatialExtent:" + spatialExtentStr);
         cmrJsonObj.add("SpatialExtent", gsonBuilder.toJsonTree(spatialExtentType).getAsJsonObject());
         String outputCMRStr = gsonBuilder.toJson(cmrJsonObj);

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/FootprintProcessor.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/FootprintProcessor.java
@@ -20,7 +20,13 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Collection;
+import java.util.ArrayList;
+
 
 /**
  * Example footprint file content (downloaded from bucket where footprint is written by forge)

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/ProcessorBase.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/ProcessorBase.java
@@ -87,7 +87,7 @@ public class ProcessorBase {
                                   String newCMRStr)
             throws IOException {
         // create a new working directory
-        AdapterLogger.LogError(this.className + " bucket:" + cmrBucket + " dir:" + cmrBaseDir +
+        AdapterLogger.LogInfo(this.className + " bucket:" + cmrBucket + " dir:" + cmrBaseDir +
                 " collectionName:"+ collectionName + " cmrFileName:"+ cmrFileName);
         String cmrFileWorkDir = this.createWorkDir();
         try {


### PR DESCRIPTION
Ticket: [PODAAC-4832](https://jira.jpl.nasa.gov/browse/PODAAC-4832)

### Description

BoundingRectangles and Footprint should be mutual exclusive.  When footprint appears, it takes priority and BoundingBox should not appear.

### Overview of work done

At footprint processor, add logic to remove BoundingRectangles in case either GPolygon or Line appeared.

### Overview of verification done

Integration testing in SNDBOX environment.  
"collection": "MODIS_A-JPL-L2P-v2019.0",

    "granuleId": "20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0",
    
   UMMG generated by the old code where both BoundingRectangles and Footprint could exist at the same time:
   
![image](https://user-images.githubusercontent.com/10672727/192804172-3d4d45ab-0613-449a-92d4-267e7efcd692.png)

* After deployed the new code, ingest the same granule again.  Only footprint appears.

![image](https://user-images.githubusercontent.com/10672727/192804416-3c97ac26-d34b-4d20-8e6b-ccf9139ae5e6.png)



#### Tested in SIT:

_Explain how you tested in SIT, if applicable_

## PR checklist:

* [x] Linted
* [ ] Unit tests
* [ ] Addressed Snyk vulnerabilities
* [x] Updated changelog
* [ ] Tested in SIT
* [ ] Documentation / User-Guide Updated

_See [Pull Request Review Checklist](https://wiki.earthdata.nasa.gov/display/PCESA/Pull+Request+Review+Checklist) for pointers on reviewing this pull request_
