### PR TITLE
taking some code from #8, used to fix a SWOT issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - remove all OPeNDAP URL object from RelatedUrls before doing dmrpp file generator processing
 - **PODAAC-4832**
   - remove BoundingRectangles structure from SpatialExtent if GPolygon appears
+- **PODAAC-5012**
+  - Fixed issue where SWOT provides a PNG and triggers the `postIngestProcess`
 ### Security
 
 ## [8.0.0] - 2022-06-06

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataAggregatorLambda.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataAggregatorLambda.java
@@ -259,14 +259,16 @@ public class MetadataAggregatorLambda implements ITask {
 					(new BigInteger(returnVars.get("revisionId"))).add(new BigInteger("1")).toString());
 			return output;
 		}
-		if (FootprintProcessor.isFootprintFileExisting(input)) {
+		// From this point, determine if we are going to process Forge workflow
+		if(workflowType == WorkflowTypeEnum.ForgeWorkflow) {
 			Hashtable<String, String> returnVars = getMetaDataHash(elrc, input);
 			FootprintProcessor processor = new FootprintProcessor();
 			output = processor.process(input, returnVars.get("ummgStr"), region,
 					(new BigInteger(returnVars.get("revisionId"))).add(new BigInteger("1")).toString());
 			return output;
 		}
-		if (ImageProcessor.isImageFileExisting(input)) {
+		// From this point, determine if we are going to process TIG workflow
+		if(workflowType == WorkflowTypeEnum.ThumbnailImageWorkflow) {
 			Hashtable<String, String> returnVars = getMetaDataHash(elrc, input);
 			ImageProcessor processor = new ImageProcessor();
 			output = processor.process(input, returnVars.get("ummgStr"), region,


### PR DESCRIPTION
This is a Cumulus 11 specific change; mirrors pr #15, feature/PODAAC-5012

This PR takes in some code from commit https://github.com/podaac/cumulus-metadata-aggregator/commit/6a1f0be3fc7c7f2d17103bca4ab60929b50ac739 where we want to be specific when we go into FORGE/TIG

Contains some extra (un-used) code for DMRPPProcessor also