### PR TITLE
Code enhancement to handle exceptions during cycle/pass/tile proces…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+### Added
 ### Deprecated
 ### Removed
 ### Fixed
+- **PODAAC-5078**
+  - Enhanced MetataAggregator to handle incorrectly formatted cycle, pass or tiles
+  - fixes maily for SWOT acrhive.xml and SWOT iso.xml
 ### Security
 
 ## [8.1.0]

--- a/pom.xml
+++ b/pom.xml
@@ -44,13 +44,13 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.12.325</version>
+      <version>1.12.346</version>
     </dependency>
     <!-- For AWS Secret Manager -->
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-secretsmanager</artifactId>
-      <version>1.12.285</version>
+      <version>1.12.346</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
@@ -560,8 +560,12 @@ public class MetadataFilesToEcho {
 			additionalAttributeTypes=
 					ummgPojoFactory.trackTypeToAdditionalAttributeTypes(trackType);
 		}
-		((IsoGranule)granule).setTrackType(trackType);
-		((IsoGranule)granule).setAdditionalAttributeTypes(additionalAttributeTypes);
+		// It is possible after all the above processing, cycle is present but passes is not (no pass in passes array)
+		// That is, we shall NOT create trackType at all.  Otherwise, CMR will throw validation error
+		if (trackType.getCycle()!=null && trackType.getPasses()!=null && trackType.getPasses().size() >0) {
+			((IsoGranule) granule).setTrackType(trackType);
+			((IsoGranule) granule).setAdditionalAttributeTypes(additionalAttributeTypes);
+		}
 		return (IsoGranule)granule;
 	}
 

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
@@ -193,21 +193,17 @@ public class MetadataFilesToEcho {
 		 * so far, universal-data-handler is not generating .mp file with tiles yet
 		 * just cycle and passes.
 		 * Passes are under cycle. If there is no cycle then there is no pass
+		 * common metadata file does not include tiles info yet, so there is no need to convert TrackType
+		 * 	 to AdditionalAttributeType Array
 		 */
-		TrackType trackType = null;
-		if (metadata.get("cycle") != null) {
-			int cycleInt = ((Long)metadata.get("cycle")).intValue();
-			Integer iPass = null;
-			if (metadata.get("pass") != null) {
-				int passInt = ((Long)metadata.get("pass")).intValue();
-				iPass = new Integer(passInt);
-			}
-			trackType = createTrackType(new Integer(cycleInt), iPass);
+		try {
+			TrackType trackType = createTrackType(NumberUtils.createInteger(metadata.get("cycle").toString()),
+					NumberUtils.createInteger(metadata.get("pass").toString()));
+			granule.setTrackType(trackType);
+		} catch (Exception e) {
+			AdapterLogger.LogWarning(this.className + " Continue execution after " +
+					"common metadata .mp extracting cycle and pass failed with exception:" + UMMUtils.getStackTraceAsString(e));
 		}
-		//  common metadata file does not include tiles info yet, so there is no need to convert TrackType
-		// to AdditionalAttributeType Array
-		granule.setTrackType(trackType);
-
 
 		if (metadata.get(Constants.Metadata.ORBIT) != null) {
 			granule.setOrbitNumber(((Long) metadata.get(Constants.Metadata.ORBIT)).intValue());
@@ -497,7 +493,14 @@ public class MetadataFilesToEcho {
         ((IsoGranule) granule).setPGEVersionClass(xpath.evaluate(IsoMendsXPath.PGE_VERSION_CLASS, doc));
 		// Process ISO cycle, pass and tile
 		String  cyclePassTileSceneStr =StringUtils.trim(xpath.evaluate(IsoMendsXPath.CYCLE_PASS_TILE_SCENE, doc));
-		createIsoCyclePassTile(cyclePassTileSceneStr);
+		try {
+			createIsoCyclePassTile(cyclePassTileSceneStr);
+		} catch (Exception e) {
+			// Since TrackType which contains Cycle Pass Tile and Scenes is not a required field
+			// we catch exception with printStackTrace to know the exact line throwing error
+			// then continue processing.
+			AdapterLogger.LogWarning("Continue processing after iso cyclePassTileScene processing failed :" +  UMMUtils.getStackTraceAsString(e));
+		}
 		return  ((IsoGranule) granule);
 	}
 
@@ -509,6 +512,7 @@ public class MetadataFilesToEcho {
 	 * @return
 	 */
 	public IsoGranule createIsoCyclePassTile(String cyclePassTileStr) {
+		cyclePassTileStr = UMMUtils.removeLineFeedCarriageReturn(cyclePassTileStr);
 		AdapterLogger.LogInfo(this.className + " iso cycle pass tile string:" + cyclePassTileStr);
 		String toBeProcessedStr = StringUtils.upperCase(StringUtils.trim(cyclePassTileStr));
 		Pattern p_cycle = Pattern.compile("CYCLE\\s*:\\s*\\d+\\s*?");
@@ -542,8 +546,16 @@ public class MetadataFilesToEcho {
 		}
 		TrackType trackType = null;
 		List<AdditionalAttributeType> additionalAttributeTypes = new ArrayList<>();
+		/**
+		 * This block of code supports multiple cycles.  In theory, during cycle transition, it is possible
+		 * a granule consists 2 cycles.  However, UMMG json schema does support one at the time.
+		 */
 		for(String cps : cyclePassStrs) {
-			trackType = createTrackType(cps, p_cycle);
+			try {
+				trackType = createTrackType(cps, p_cycle);
+			} catch (Exception e) {
+				AdapterLogger.LogWarning(this.className + " continue processing after creating TrackType with exception: " + UMMUtils.getStackTraceAsString(e));
+			}
 			UmmgPojoFactory ummgPojoFactory = UmmgPojoFactory.getInstance();
 			additionalAttributeTypes=
 					ummgPojoFactory.trackTypeToAdditionalAttributeTypes(trackType);
@@ -586,8 +598,13 @@ public class MetadataFilesToEcho {
 			String[] passTiles = StringUtils.split(passTilesStr, ",");
 			String passStr = StringUtils.trim(passTiles[0]);
 			trackPassTileType.setPass(NumberUtils.createInteger(passStr));
-			List<String> tiles = getTiles(StringUtils.trim(passTiles[1]));
-			trackPassTileType.setTiles(tiles);
+			try {
+				List<String> tiles = getTiles(StringUtils.trim(passTiles[1]));
+				trackPassTileType.setTiles(tiles);
+			} catch (Exception e) {
+				AdapterLogger.LogWarning(this.className + " Continue processing after tile processing failed with " +
+						"exception: " + UMMUtils.getStackTraceAsString(e));
+			}
 			trackPassTileTypes.add(trackPassTileType);
 		}
 		trackType.setPasses(trackPassTileTypes);
@@ -711,6 +728,47 @@ public class MetadataFilesToEcho {
 		String  passStr  =StringUtils.trim(xpath.evaluate(SwotArchiveXmlXPath.ARCHIVE_PASS, doc));
 		String  tileStr  =StringUtils.trim(xpath.evaluate(SwotArchiveXmlXPath.ARCHIVE_TILE, doc));
 
+		// TrackType is not a required field.  Hence, if thrown exception during process, we will swallow exception
+		// log and continue
+		TrackType trackType;
+		try {
+			trackType = createTrackType(cycleStr, passStr, tileStr);
+			granule.setTrackType(trackType);
+			granule.setAdditionalAttributeTypes(UmmgPojoFactory.getInstance().trackTypeToAdditionalAttributeTypes(trackType));
+		} catch (Exception e) {
+			AdapterLogger.LogWarning(this.className + " Exception while creating TrackType: " + UMMUtils.getStackTraceAsString(e));
+		}
+		return granule;
+	}
+
+	/**
+	 * to create TrackType, cycle and passes are both required.
+	 * However, within each passes (TrackPassTileType), only pass is required.
+	 * i.e., it is possible we can have TrackPassTileType with pass but no tile
+	 *
+	 * However, the Track (TrackType) under HorizontalSpatialDomainType, is not required.
+	 * https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.3/umm-g-json-schema.json#514
+	 * @param cycleStr
+	 * @param passStr
+	 * @param tileStr
+	 * @return
+	 */
+	public TrackType createTrackType(String cycleStr, String passStr, String tileStr) {
+		/*
+		based on the "do as much we can" theory.  the code shall only allow the situation where
+		title can not be processed, since cycle and passes are both required.
+		According to UMMG schema 1.6.3, cycle and pass are both integer.  tile is String
+		 */
+		try {
+			if (NumberUtils.createInteger(StringUtils.trim(cycleStr)) == null ||
+					NumberUtils.createInteger(StringUtils.trim(passStr)) == null) {
+				return null;
+			}
+		} catch(NumberFormatException nfe) { // if either cycle or pass are un-processable, then return null
+			AdapterLogger.LogWarning(this.className+ " cycle or pass string can not be converted to Integer :" + UMMUtils.getStackTraceAsString(nfe));
+			throw nfe;
+		}
+
 		ArrayList<TrackPassTileType>trackPassTileTypes = new ArrayList<>();
 		TrackType trackType = null;
 		if (StringUtils.isNotEmpty(passStr)) {
@@ -726,9 +784,7 @@ public class MetadataFilesToEcho {
 		if (StringUtils.isNotEmpty(cycleStr)) {
 			trackType = ummgPojoFactory.createTrackType(NumberUtils.createInteger(cycleStr), trackPassTileTypes);
 		}
-		granule.setTrackType(trackType);
-		granule.setAdditionalAttributeTypes(UmmgPojoFactory.getInstance().trackTypeToAdditionalAttributeTypes(trackType));
-		return granule;
+		return trackType;
 	}
 
 	/**
@@ -781,8 +837,12 @@ public class MetadataFilesToEcho {
 		String cycle = StringUtils.trim(xpath.evaluate(ManifestXPath.CYCLE, doc));
 		String pass = StringUtils.trim(xpath.evaluate(ManifestXPath.PASS, doc));
 
-		TrackType trackType = createTrackType(NumberUtils.createInteger(cycle), NumberUtils.createInteger(pass));
-		granule.setTrackType(trackType); // No tile so we don't need to convert trackType to AdditionalAttributeType array
+		try {  // TrackType is not a required field hence continue execution if any exception happened.
+			TrackType trackType = createTrackType(NumberUtils.createInteger(cycle), NumberUtils.createInteger(pass));
+			granule.setTrackType(trackType); // No tile so we don't need to convert trackType to AdditionalAttributeType array
+		} catch (Exception e) {
+			AdapterLogger.LogWarning(this.className + " Continue execution after s6 creating TrackType failed with exception:" + e);
+		}
 
 		String productName = null;
 		try {

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/UMMUtils.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/UMMUtils.java
@@ -1,5 +1,7 @@
 package gov.nasa.cumulus.metadata.aggregator;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 
 import java.util.List;
@@ -9,6 +11,7 @@ import com.vividsolutions.jts.algorithm.CGAlgorithms;
 import com.vividsolutions.jts.io.WKTWriter;
 import gov.nasa.podaac.inventory.model.Dataset;
 import gov.nasa.podaac.inventory.model.DatasetCitation;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -301,6 +304,18 @@ public class UMMUtils {
     public static Double longitudeTypeNormalizer(Double value) {
         value = value > 180 ? value - 360 : value;
         return value;
+    }
+
+    public static String removeLineFeedCarriageReturn(String s){
+        if (s==null) s="";
+        return StringUtils.trim(s).replace("\n"," ").replace("\r", " ");
+    }
+
+    public static String getStackTraceAsString(Exception e) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        e.printStackTrace(pw);
+        return sw.toString();
     }
 
 }

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/factory/UmmgPojoFactory.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/factory/UmmgPojoFactory.java
@@ -6,6 +6,7 @@ import gov.nasa.cumulus.metadata.umm.generated.TrackType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class UmmgPojoFactory {
     private static UmmgPojoFactory _self = null;
@@ -48,6 +49,10 @@ public class UmmgPojoFactory {
 
     public List<AdditionalAttributeType> trackTypeToAdditionalAttributeTypes(TrackType trackType) {
         List<TrackPassTileType> trackPassTileTypes = trackType.getPasses();
+        trackPassTileTypes = trackPassTileTypes.stream().filter(trackPassTileType ->
+                trackPassTileType.getPass()!=null
+                        && trackPassTileType.getTiles() !=null
+        && trackPassTileType.getTiles().size() >0).collect(Collectors.toList());
         ArrayList<AdditionalAttributeType> additionalAttributeTypes = new ArrayList<>();
         trackPassTileTypes.stream().forEach(trackPassTileType ->  {
             AdditionalAttributeType additionalAttributeType = new AdditionalAttributeType();

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/AdditionalAttributeType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/AdditionalAttributeType.java
@@ -31,6 +31,24 @@ public class AdditionalAttributeType {
     private List<String> values = new ArrayList<String>();
 
     /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public AdditionalAttributeType() {
+    }
+
+    /**
+     * 
+     * @param values
+     * @param name
+     */
+    public AdditionalAttributeType(String name, List<String> values) {
+        super();
+        this.name = name;
+        this.values = values;
+    }
+
+    /**
      * The additional attribute's name.
      * (Required)
      * 

--- a/src/test/java/gov/nasa/cumulus/metadata/aggregator/UMMUtilsTest.java
+++ b/src/test/java/gov/nasa/cumulus/metadata/aggregator/UMMUtilsTest.java
@@ -14,6 +14,7 @@ import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.Before;
 import static org.junit.Assert.assertTrue;
@@ -179,7 +180,19 @@ public class UMMUtilsTest {
             // force test case to fail if getting exception
             assertTrue(false);
         }
+    }
 
+    @Test
+    public void testExceptionStackTraceToString() {
+        try {
+            NumberFormatException numberFormatException = new NumberFormatException("Self generated NumberFormatException");
+            String stackTraceStr = UMMUtils.getStackTraceAsString(numberFormatException);
+            assertTrue(StringUtils.containsIgnoreCase(stackTraceStr,"gov.nasa.cumulus.metadata.aggregator.UMMUtilsTest.testExceptionStackTraceToString"));
+            assertTrue(StringUtils.containsIgnoreCase(stackTraceStr,"Self generated NumberFormatException"));
+        } catch (Exception e) {
+            // force test case to fail if getting exception
+            assertTrue(false);
+        }
     }
 
 }

--- a/src/test/java/gov/nasa/cumulus/metadata/test/MetadataFilesToEchoTest.java
+++ b/src/test/java/gov/nasa/cumulus/metadata/test/MetadataFilesToEchoTest.java
@@ -256,8 +256,32 @@ public class MetadataFilesToEchoTest {
     }
 
     @Test
+    public void testCreateTrackTypeWithException () {
+        String input = "Cycle: 5 Pass: [40, Tiles: 4-5L 4-8R] [41, Tiles: 6R 6L] [42, Tiles: 7F]";
+        ClassLoader classLoader = getClass().getClassLoader();
+        File cfgFile = new File(classLoader.getResource("MODIS_T-JPL-L2P-v2014.0.cmr.cfg").getFile());
+        MetadataFilesToEcho mfte = new MetadataFilesToEcho(true);
+
+        try {
+            mfte.readConfiguration(cfgFile.getAbsolutePath());
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+        // if passed in UNKNOWN for either cycle or pass, then NumberFormatException will be thrown
+        assertThrows(NumberFormatException.class, () -> mfte.createTrackType("UNKNOWN", "UNKNOWN", "UNKNOWN"));
+        // if  both cycle and pass string are re-presenting Integer
+        TrackType trackType = mfte.createTrackType("3", "2", "UNKNOWN");
+        assertEquals(trackType.getCycle().intValue(), 3);
+        List<TrackPassTileType> trackPassTileTypes = trackType.getPasses();
+        TrackPassTileType trackPassTileType = trackPassTileTypes.get(0);
+        assertEquals(trackPassTileType.getPass().intValue(), 2);
+        assertEquals(trackPassTileType.getTiles().get(0), "UNKNOWN");
+    }
+    @Test
     public void testMarshellCyclePassTileSceneStrToAchiveType() {
         String input = "Cycle: 5 Pass: [40, Tiles: 4-5L 4-8R] [41, Tiles: 6R 6L] [42, Tiles: 7F]";
+        //input = "Cycle: 5 Pass: [40, Tiles: 40R-50R 4-8R] [41, Tiles: 6R 6L] [42, Tiles: 7F]";
         ClassLoader classLoader = getClass().getClassLoader();
         File cfgFile = new File(classLoader.getResource("MODIS_T-JPL-L2P-v2014.0.cmr.cfg").getFile());
         MetadataFilesToEcho mfte = new MetadataFilesToEcho(true);
@@ -281,6 +305,37 @@ public class MetadataFilesToEchoTest {
         assertEquals(tiles.get(6), "8R");
         List<AdditionalAttributeType> additionalAttributeTypes = isoGranule.getAdditionalAttributeTypes();
         assertEquals(additionalAttributeTypes.size(), 3);
+        // The following test purposely make tile 40R-50R breaking the code.  However, pass 41, 6R 6L shall
+        // still appear in the tiles array
+        input = "Cycle: 5 Pass: [40, Tiles: 40R-50R 4-8R] [41, Tiles: 6R 6L] [42, Tiles: 7-10F]";
+        isoGranule = mfte.createIsoCyclePassTile(input);
+        trackType = isoGranule.getTrackType();
+        trackPassTileTypes = trackType.getPasses();
+        assertEquals(trackPassTileTypes.size(), 3);
+        trackPassTileType = trackPassTileTypes.get(0);
+        assertEquals(trackPassTileType.getPass(), new Integer(40));
+        tiles = trackPassTileType.getTiles();
+        assertEquals(tiles.size(), 0);
+        trackPassTileType = trackPassTileTypes.get(1); //[41, Tiles: 6R 6L]
+        assertEquals(trackPassTileType.getPass(), new Integer(41));
+        tiles = trackPassTileType.getTiles();
+        assertEquals(tiles.size(), 2);
+        assertEquals(tiles.get(0), "6R");
+        assertEquals(tiles.get(1), "6L");
+        trackPassTileType = trackPassTileTypes.get(2);  // [42, Tiles: 7-10F]
+        assertEquals(trackPassTileType.getPass(), new Integer(42));
+        tiles = trackPassTileType.getTiles();
+        assertEquals(tiles.size(), 4);
+        assertEquals(tiles.get(0), "7F");
+        assertEquals(tiles.get(3), "10F");
+        additionalAttributeTypes = isoGranule.getAdditionalAttributeTypes();
+        assertEquals(additionalAttributeTypes.size(), 3);
+        AdditionalAttributeType additionalAttributeType = additionalAttributeTypes.get(2);  // TILE, 7F, 8F, 9F, 10F
+        assertEquals(additionalAttributeType.getName(), "TILE");
+        List<String> tileValues = additionalAttributeType.getValues();  //7F, 8F, 9F, 10F
+        assertEquals(tileValues.get(0), "7F");
+        assertEquals(tileValues.get(3), "10F");
+
     }
 
     @Test
@@ -314,8 +369,6 @@ public class MetadataFilesToEchoTest {
             e.printStackTrace();
             fail();
         }
-
-
     }
 
 }

--- a/src/test/java/gov/nasa/cumulus/metadata/test/MetadataFilesToEchoTest.java
+++ b/src/test/java/gov/nasa/cumulus/metadata/test/MetadataFilesToEchoTest.java
@@ -281,7 +281,6 @@ public class MetadataFilesToEchoTest {
     @Test
     public void testMarshellCyclePassTileSceneStrToAchiveType() {
         String input = "Cycle: 5 Pass: [40, Tiles: 4-5L 4-8R] [41, Tiles: 6R 6L] [42, Tiles: 7F]";
-        //input = "Cycle: 5 Pass: [40, Tiles: 40R-50R 4-8R] [41, Tiles: 6R 6L] [42, Tiles: 7F]";
         ClassLoader classLoader = getClass().getClassLoader();
         File cfgFile = new File(classLoader.getResource("MODIS_T-JPL-L2P-v2014.0.cmr.cfg").getFile());
         MetadataFilesToEcho mfte = new MetadataFilesToEcho(true);
@@ -329,8 +328,8 @@ public class MetadataFilesToEchoTest {
         assertEquals(tiles.get(0), "7F");
         assertEquals(tiles.get(3), "10F");
         additionalAttributeTypes = isoGranule.getAdditionalAttributeTypes();
-        assertEquals(additionalAttributeTypes.size(), 3);
-        AdditionalAttributeType additionalAttributeType = additionalAttributeTypes.get(2);  // TILE, 7F, 8F, 9F, 10F
+        assertEquals(additionalAttributeTypes.size(), 2);
+        AdditionalAttributeType additionalAttributeType = additionalAttributeTypes.get(1);  // TILE, 7F, 8F, 9F, 10F
         assertEquals(additionalAttributeType.getName(), "TILE");
         List<String> tileValues = additionalAttributeType.getValues();  //7F, 8F, 9F, 10F
         assertEquals(tileValues.get(0), "7F");


### PR DESCRIPTION
Ticket: [PODAAC-5078](https://jira.jpl.nasa.gov/browse/PODAAC-5078)

### Description

Enhanced code logic to process cycl/pass/tiles strings in wrong format.
Ex.
swot archive.xml
<Cycle>Unknown</Cycle>  where an integer is expected

### Overview of work done

Add exception catching on different place and give up tile if cycle and pass are presented in good format
In case cycle or pass can not be processed.  Abandon the TrackType and make the code continue for TrackType is not a required field

### Overview of verification done

Unit testing.
Integration tested in SNDBX environment with the following cnm

{
  "product": {
    "files": [
      {
        "checksumType": "md5",
        "size": 52549,
        "type": "data",
        "uri": "s3://podaac-dev-cumulus-test-input-v2/L1B_LR_INTF/SWOT_L1B_LR_INTF_001_005_20210612T230815_20210612T235103_PGA2_03.tar.gz",
        "name": "SWOT_L1B_LR_INTF_001_005_20210612T230815_20210612T235103_PGA2_03.tar.gz"
      }
    ],
    "name": "SWOT_L1B_LR_INTF_001_005_20210612T230815_20210612T235103_PGA2_03.tar.gz",
    "dataVersion": "1.0",
    "dataProcessingType": "forward"
  },
  "trace": "NCL1B_LR_INTF",
  "collection": "L1B_LR_INTF",
  "version": "1.0",
  "provider": "PODAAC",
  "submissionTime": "2020-05-13T20:42:32.682418",
  "identifier": "45150e51-955a-11ea-80e5-acde48001122"
}

where such collection seems not totally setup correctly ("seems" because we could retrieve such collection from CMR but cmrPOST says such collection with provider = POCUMULUS is not found).

If downloaded and unpacked above .tar.gz,  the nc.iso.xml will represent an incorrect cycle/pass/tiles string where tiles represents as 40R-50R

anyway, above ingestion created a cmr.json which validated against cmr 1.6.3 schema without error.  During integration, we did found bugs and fixed them

* Both Cycle and at least one Pass shall be present in the TrackType
* While TrackPassTileType containing pass and relative tiles.  If tiles array is null or empty, then the correlated AdditionalAttribute shall not be created.


#### Tested in SIT:

_Explain how you tested in SIT, if applicable_

## PR checklist:

* [x] Linted
* [x] Unit tests
* [x] Addressed Snyk vulnerabilities
* [x] Updated changelog
* [ ] Tested in SIT
* [ ] Documentation / User-Guide Updated

_See [Pull Request Review Checklist](https://wiki.earthdata.nasa.gov/display/PCESA/Pull+Request+Review+Checklist) for pointers on reviewing this pull request_
