### PR TITLE
[PODAAC-5089] Insert extra data for .png files for `CMR.JSON` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-### Added
+- **PODAAC-5089**
+  - For each PNG file for granule, append metadata and mimetype for `cmr.json` file
 ### Deprecated
 ### Removed
 ### Fixed
 ### Security
 
 ## [8.2.0]
-### Added
 ### Added
 ### Deprecated
 ### Removed

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.12.346</version>
+      <version>1.12.378</version>
     </dependency>
     <!-- For AWS Secret Manager -->
     <dependency>

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/UMMGranuleFile.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/UMMGranuleFile.java
@@ -798,10 +798,15 @@ public class UMMGranuleFile {
             String type = reference.getType();
             JSONObject relatedUrl = new JSONObject();
             if (!type.startsWith(Constant.LocationPolicyType.ARCHIVE.toString())) {
-
                 if (accessURLs.add(reference.getPath())) {
                     relatedUrl.put("URL", reference.getPath());
-                    relatedUrl.put("Type", "GET DATA");
+                    if(reference.getPath().endsWith(".png")){
+                        relatedUrl.put("Type", "GET RELATED VISUALIZATION");
+                        relatedUrl.put("Subtype", "DIRECT DOWNLOAD");
+                        relatedUrl.put("MimeType", "image/png");
+                    } else {
+                        relatedUrl.put("Type", "GET DATA");
+                    }
                     log.info("Access URL \"" + reference.getPath() + "\" will be added to granule export information");
 
                     if (type.endsWith("FTP"))

--- a/src/test/java/gov/nasa/cumulus/metadata/test/MetadataFilesToEchoTest.java
+++ b/src/test/java/gov/nasa/cumulus/metadata/test/MetadataFilesToEchoTest.java
@@ -207,7 +207,7 @@ public class MetadataFilesToEchoTest {
 
         File file2 = new File(classLoader.getResource("JA1_GPN_2PeP374_172_20120303_112035_20120303_121638.nc.mp").getFile());
         try {
-            mfte.readCommonMetadataFile(file2.getAbsolutePath(), "s3://a/path/to/s3");
+            mfte.readCommonMetadataFile(file2.getAbsolutePath(), "s3://a/path/to/s3.png");
         } catch (Exception e) {
             e.printStackTrace();
             fail();
@@ -368,6 +368,42 @@ public class MetadataFilesToEchoTest {
             e.printStackTrace();
             fail();
         }
+    }
+
+    @Test
+    public void testCreateJsonWithPNGFile()
+            throws ParseException, IOException, URISyntaxException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("MODIS_T-JPL-L2P-v2014.0.cmr.cfg").getFile());
+        MetadataFilesToEcho mfte = new MetadataFilesToEcho();
+        try {
+            mfte.readConfiguration(file.getAbsolutePath());
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+
+        File file2 = new File(classLoader.getResource("20170408033000-JPL-L2P_GHRSST-SSTskin-MODIS_T-N-v02.0-fv01.0.nc.mp").getFile());
+        try {
+            mfte.readCommonMetadataFile(file2.getAbsolutePath(), "s3://a/path/to/s3.png");
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+
+        mfte.getGranule().setName("20170408033000-JPL-L2P_GHRSST-SSTskin-MODIS_T-N-v02.0-fv01.0");
+
+        JSONObject granule = mfte.createJson();
+        System.out.println(granule.toJSONString());
+        assertEquals("20170408033000-JPL-L2P_GHRSST-SSTskin-MODIS_T-N-v02.0-fv01.0", granule.get("GranuleUR"));
+
+        JSONObject temp = (JSONObject) ((JSONArray) granule.get("RelatedUrls")).get(0);
+        String mimeType = (String) temp.get("MimeType");
+        String subType = (String) temp.get("Subtype");
+
+        assertEquals("image/png", mimeType);
+        assertEquals("DIRECT DOWNLOAD", subType);
+
     }
 
 }

--- a/src/test/java/gov/nasa/cumulus/metadata/test/MetadataFilesToEchoTest.java
+++ b/src/test/java/gov/nasa/cumulus/metadata/test/MetadataFilesToEchoTest.java
@@ -376,20 +376,9 @@ public class MetadataFilesToEchoTest {
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("MODIS_T-JPL-L2P-v2014.0.cmr.cfg").getFile());
         MetadataFilesToEcho mfte = new MetadataFilesToEcho();
-        try {
-            mfte.readConfiguration(file.getAbsolutePath());
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail();
-        }
-
+        mfte.readConfiguration(file.getAbsolutePath());
         File file2 = new File(classLoader.getResource("20170408033000-JPL-L2P_GHRSST-SSTskin-MODIS_T-N-v02.0-fv01.0.nc.mp").getFile());
-        try {
-            mfte.readCommonMetadataFile(file2.getAbsolutePath(), "s3://a/path/to/s3.png");
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail();
-        }
+        mfte.readCommonMetadataFile(file2.getAbsolutePath(), "s3://a/path/to/s3.png");
 
         mfte.getGranule().setName("20170408033000-JPL-L2P_GHRSST-SSTskin-MODIS_T-N-v02.0-fv01.0");
 


### PR DESCRIPTION
### Description

When processing a .png file within granule, when generating CMR.JSON, for `relatedUrl`, add in `MimeType` and `SubType` info

### Overview of work done

Identify where `cmr.json` adds in relatedURL info, then set up to when seeing a PNG add in metadata; create unit test also

### Overview of verification done

Ran in Sandbox, confirmed `CMR.JSON` for .png file has extra data

#### Tested in SIT:

N/A

## PR checklist:

* [ ] Linted
* [x] Unit tests
* [x] Addressed Snyk vulnerabilities
* [x] Updated changelog
* [ ] Tested in SIT
* [ ] Documentation / User-Guide Updated