### PR TITLE
PODAAC-5053: MGRS metadata ingested for OPERA products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enable metadata aggregator to append Additional Attribute(s) into CMR.JSON as its own root key
 - **PODAAC-5089**
   - For each PNG file for granule, append metadata and mimetype for `cmr.json` file
+- **PODAAC-5053**
+  - Extract MGRS_TILE_ID metadata from iso.xml. Used for OPERA processing
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/IsoMendsXPath.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/IsoMendsXPath.java
@@ -38,4 +38,6 @@ public final class IsoMendsXPath extends IsoXPath {
     public static final String CYCLE_PASS_TILE_SCENE = "/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicDescription[@id=\"SWOTTrack\"]/gmd:geographicIdentifier/gmd:MD_Identifier/gmd:code/gco:CharacterString";
 
     public static final String ADDITIONAL_ATTRIBUTES_BLOCK = "/gmi:MI_Metadata/gmd:contentInfo/gmd:MD_CoverageDescription/gmd:dimension/gmd:MD_Band/gmd:otherProperty/gco:Record/eos:AdditionalAttributes/eos:AdditionalAttribute//eos:name/gco:CharacterString|//eos:value/gco:CharacterString";
+    public static final String MGRS_ID = "/gmi:MI_Metadata/gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/gmd:referenceSystemIdentifier/gmd:MD_Identifier/gmd:code/gco:CharacterString";
+
 }

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
@@ -532,6 +532,29 @@ public class MetadataFilesToEcho {
 			additionalAttributes.remove("publishAll");
 			((IsoGranule) granule).setDynamicAttributeNameMapping(additionalAttributes);
 		}
+		
+					
+        String mgrsId = xpath.evaluate(IsoMendsXPath.MGRS_ID, doc);
+        if (mgrsId != null && !mgrsId.equals("")) {
+            // If MGRS_ID field is not null, set as additional attribute
+            AdditionalAttributeType mgrsAttr = new AdditionalAttributeType("MGRS_TILE_ID", Collections.singletonList(mgrsId));
+            
+            List<AdditionalAttributeType> additionalAttributeTypes = ((IsoGranule) granule).getAdditionalAttributeTypes();
+            if (additionalAttributeTypes == null) {
+                additionalAttributeTypes = Collections.singletonList(mgrsAttr);
+            } else {
+                additionalAttributeTypes.add(mgrsAttr);
+            }
+            
+            JSONObject dynamicAttributeNameMapping = ((IsoGranule) granule).getDynamicAttributeNameMapping();
+            if (dynamicAttributeNameMapping == null) {
+                ((IsoGranule) granule).setDynamicAttributeNameMapping(additionalAttributes);
+            } else {
+                dynamicAttributeNameMapping.put("MGRS_TILE_ID", Collections.singletonList(mgrsId));
+            }
+            ((IsoGranule) granule).setAdditionalAttributeTypes(additionalAttributeTypes);
+            ((IsoGranule) granule).setDynamicAttributeNameMapping(dynamicAttributeNameMapping);
+        }
 
 		return  ((IsoGranule) granule);
 	}

--- a/src/test/java/gov/nasa/cumulus/metadata/test/MetadataFilesToEchoTest.java
+++ b/src/test/java/gov/nasa/cumulus/metadata/test/MetadataFilesToEchoTest.java
@@ -25,8 +25,11 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.junit.Test;
 import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -371,7 +374,7 @@ public class MetadataFilesToEchoTest {
     }
 
     @Test
-    public void testReadIsoMendsMetadataFileAdditionalFields_publishAll() throws ParseException, IOException, URISyntaxException {
+    public void testReadIsoMendsMetadataFileAdditionalFields_publishAll() throws ParseException, IOException, URISyntaxException, XPathExpressionException, ParserConfigurationException, SAXException {
 
         // Simple "publishAll" is true
 
@@ -382,50 +385,68 @@ public class MetadataFilesToEchoTest {
 
         Document doc = null;
         XPath xpath = null;
-        try {
-            mfte.readConfiguration(cfgFile.getAbsolutePath());
-            doc = mfte.makeDoc(file.getAbsolutePath());
-            xpath = mfte.makeXpath(doc);
-            IsoGranule isoGranule = mfte.readIsoMendsMetadataFile("s3://mybucket/mygranule.nc",  doc,  xpath);
 
-            File file2 = new File(classLoader.getResource("JA1_GPN_2PeP374_172_20120303_112035_20120303_121638.nc.mp").getFile());
-            try {
-                mfte.readCommonMetadataFile(file2.getAbsolutePath(), "s3://a/path/to/s3");
-            } catch (Exception e) {
-                e.printStackTrace();
-                fail();
-            }
+        mfte.readConfiguration(cfgFile.getAbsolutePath());
+        doc = mfte.makeDoc(file.getAbsolutePath());
+        xpath = mfte.makeXpath(doc);
+        IsoGranule isoGranule = mfte.readIsoMendsMetadataFile("s3://mybucket/mygranule.nc",  doc,  xpath);
 
-            // Verify the values here:
+        File file2 = new File(classLoader.getResource("JA1_GPN_2PeP374_172_20120303_112035_20120303_121638.nc.mp").getFile());
+        mfte.readCommonMetadataFile(file2.getAbsolutePath(), "s3://a/path/to/s3");
 
-            // Confirm additional attributes has been filled
-            List<AdditionalAttributeType> aat = isoGranule.getAdditionalAttributeTypes();
-            assertEquals(aat.size(), 10);
+        // Verify the values here:
 
-            List<String> keys = aat.stream().map(AdditionalAttributeType::getName).collect(Collectors.toList());
+        // Confirm additional attributes has been filled
+        List<AdditionalAttributeType> aat = isoGranule.getAdditionalAttributeTypes();
+        assertEquals(aat.size(), 11);
 
-            List<String> checkForKey = Arrays.asList("HlsDataset",
-                    "SensorProductID",
-                    "Accode",
-                    "MeanSunAzimuthAngle",
-                    "MeanSunZenithAngle",
-                    "NBAR_SolarZenith",
-                    "MeanViewAzimuthAngle",
-                    "MeanViewZenithAngle",
-                    "SpatialCoverage",
-                    "PercentCloudCover");
+        List<String> keys = aat.stream().map(AdditionalAttributeType::getName).collect(Collectors.toList());
 
-            if(!checkForKey.equals(keys)){
-                fail(String.format("List mismatch:\n" +
-                        Arrays.toString(keys.toArray()) + "\n" +
-                        Arrays.toString(checkForKey.toArray())));
-            }
+        List<String> checkForKey = Arrays.asList("HlsDataset",
+                "SensorProductID",
+                "Accode",
+                "MeanSunAzimuthAngle",
+                "MeanSunZenithAngle",
+                "NBAR_SolarZenith",
+                "MeanViewAzimuthAngle",
+                "MeanViewZenithAngle",
+                "SpatialCoverage",
+                "PercentCloudCover",
+                "MGRS_TILE_ID"
+        );
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail();
+        if(!checkForKey.equals(keys)){
+            fail(String.format("List mismatch:\n" +
+                    Arrays.toString(keys.toArray()) + "\n" +
+                    Arrays.toString(checkForKey.toArray())));
         }
     }
+    
+    /**
+     * Test that confirms MGRS_TILE_ID additional attribute is present even when no other additional attributes
+     * are present
+     */
+    @Test
+    public void testReadIsoMendsMetadataFileNoAdditionalFieldsMGRS() throws ParserConfigurationException, IOException, SAXException, XPathExpressionException, ParseException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("OPERA_L3_DSWx_HLS_T14RNV_20210906T170251Z_20221026T184342Z_L8_30_v0.0.iso.xml").getFile());
+        MetadataFilesToEcho mfte = new MetadataFilesToEcho(true);
+
+        Document doc = null;
+        XPath xpath = null;
+
+        doc = mfte.makeDoc(file.getAbsolutePath());
+        xpath = mfte.makeXpath(doc);
+        IsoGranule isoGranule = mfte.readIsoMendsMetadataFile("s3://mybucket/mygranule.nc",  doc,  xpath);
+
+        File file2 = new File(classLoader.getResource("JA1_GPN_2PeP374_172_20120303_112035_20120303_121638.nc.mp").getFile());
+        
+        // Confirm additional attribute has been filled
+        List<AdditionalAttributeType> aat = isoGranule.getAdditionalAttributeTypes();
+        assertEquals(aat.size(), 1);
+        assertEquals(aat.get(0).getName(), "MGRS_TILE_ID");
+    }
+    
 
     @Test
     public void testReadIsoMendsMetadataFileAdditionalFields_appendFieldToJSON() throws ParseException, IOException, URISyntaxException {
@@ -457,7 +478,7 @@ public class MetadataFilesToEchoTest {
 
             // Confirm additional attributes has been filled
             List<AdditionalAttributeType> aat = isoGranule.getAdditionalAttributeTypes();
-            assertEquals(aat.size(), 10);
+            assertEquals(aat.size(), 11);  // 10 additional attributes + MGRS_TILE_ID
 
             List<String> keys = aat.stream().map(AdditionalAttributeType::getName).collect(Collectors.toList());
 
@@ -470,7 +491,9 @@ public class MetadataFilesToEchoTest {
                     "MeanViewAzimuthAngle",
                     "MeanViewZenithAngle",
                     "SpatialCoverage",
-                    "PercentCloudCover");
+                    "PercentCloudCover",
+                    "MGRS_TILE_ID"
+            );
 
             if(!checkForKey.equals(keys)){
                 fail(String.format("List mismatch:\n" +
@@ -541,11 +564,11 @@ public class MetadataFilesToEchoTest {
 
             // Confirm additional attributes has been filled
             List<AdditionalAttributeType> aat = isoGranule.getAdditionalAttributeTypes();
-            assertEquals(aat.size(), 1);
+            assertEquals(aat.size(), 2);
 
             List<String> keys = aat.stream().map(AdditionalAttributeType::getName).collect(Collectors.toList());
 
-            List<String> checkForKey = Arrays.asList("PercentCloudCover");
+            List<String> checkForKey = Arrays.asList("PercentCloudCover", "MGRS_TILE_ID");
 
             if(!checkForKey.equals(keys)){
                 fail(String.format("List mismatch:\n" +
@@ -589,7 +612,7 @@ public class MetadataFilesToEchoTest {
 
             // Confirm additional attributes has been filled
             List<AdditionalAttributeType> aat = isoGranule.getAdditionalAttributeTypes();
-            assertEquals(aat.size(), 10);
+            assertEquals(aat.size(), 11);
 
             List<String> keys = aat.stream().map(AdditionalAttributeType::getName).collect(Collectors.toList());
 
@@ -602,7 +625,9 @@ public class MetadataFilesToEchoTest {
                     "MeanViewAzimuthAngle",
                     "MeanViewZenithAngle",
                     "SpatialCoverage",
-                    "PercentCloudCover");
+                    "PercentCloudCover",
+                    "MGRS_TILE_ID"
+            );
 
             if(!checkForKey.equals(keys)){
                 fail(String.format("List mismatch:\n" +
@@ -739,11 +764,11 @@ public class MetadataFilesToEchoTest {
 
             // Confirm additional attributes has been filled
             List<AdditionalAttributeType> aat = isoGranule.getAdditionalAttributeTypes();
-            assertEquals(aat.size(), 1);
+            assertEquals(aat.size(), 2);
 
             List<String> keys = aat.stream().map(AdditionalAttributeType::getName).collect(Collectors.toList());
 
-            List<String> checkForKey = Arrays.asList("SensorProductID");
+            List<String> checkForKey = Arrays.asList("SensorProductID", "MGRS_TILE_ID");
 
             if(!checkForKey.equals(keys)){
                 fail(String.format("List mismatch:\n" +


### PR DESCRIPTION
If present, extract MGRS_ID from iso.xml metadata. This is needed for OPERA. This code was a bit long as we have to support both cases where there are and aren't already additional attributes. 

* Updated `MetadataFilesToEcho` to check for MGRS_ID. If present, add to additional attributes.
* Updated OPERA existing unit tests to support this change -- many needed minor updates as they now had one more additional attribute to expect.
* Added a new unit test case `testReadIsoMendsMetadataFileNoAdditionalFieldsMGRS` which tests the case where no other additional attributes are provided. 
* Updated changelog
* Updated some test cases to remove unnecessary try/catch (I'd like to start slowly removing these to clean these tests up)