### PR TITLE
PODAAC-5201: Support SWOT Cal/Val xml format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enable metadata aggregator to append Additional Attribute(s) into CMR.JSON as its own root key
 - **PODAAC-5089**
   - For each PNG file for granule, append metadata and mimetype for `cmr.json` file
+- **PODAAC-5201**
+  - Support SWOT Cal/Val XML format
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataAggregatorLambda.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataAggregatorLambda.java
@@ -58,6 +58,7 @@ public class MetadataAggregatorLambda implements ITask {
 
 		String isoRegex = (String) config.get("isoRegex");
 		String archiveXmlRegex = (String) config.get("archiveXmlRegex");
+		String calValXmlRegex = (String) config.get("calValXmlRegex");
 		String granuleId = (String) config.get("granuleId");
 		context.getLogger().log("Started processing: " + granuleId);
 		String internalBucket = (String) config.get("internalBucket");
@@ -94,6 +95,7 @@ public class MetadataAggregatorLambda implements ITask {
 		String iso = null;
 		String xfdumanifest = null;
 		String archiveXml = null;
+		String calValXml = null;
 		// the bucket and key for .mp file
 		String mpFileBucket = null;
 		String mpFileKey = null;
@@ -125,7 +127,12 @@ public class MetadataAggregatorLambda implements ITask {
 			} else if (archiveXmlRegex != null && filename.matches(archiveXmlRegex)) {
 				archiveXml = s3Utils.download(region, (String) file.get("bucket"), key,
 						Paths.get("/tmp", filename).toString());
-			}
+			} else if (calValXmlRegex != null && filename.matches(calValXmlRegex)) {
+                AdapterLogger.LogDebug(this.className + " download CalVal XML from bucket:" +
+                        file.get("bucket") + "  key" + file.get("key") + " to:" + Paths.get("/tmp", filename));
+                calValXml = s3Utils.download(region, (String) file.get("bucket"), key,
+                        Paths.get("/tmp", filename).toString());
+            }
 		}
 
 		//remove the fp and mp files from the array
@@ -161,6 +168,7 @@ public class MetadataAggregatorLambda implements ITask {
 				if (footprint != null) mtfe.readFootprintFile(footprint);
 				if (xfdumanifest != null) mtfe.readSentinelManifest(xfdumanifest);
 				if (archiveXml != null) mtfe.readSwotArchiveXmlFile(archiveXml);
+				if (calValXml != null) mtfe.readSwotCalValXmlFile(calValXml);
 			} catch (IOException | ParseException e) {
 				AdapterLogger.LogError(this.className + " MetadataFilesToEcho input FALSE read error:" + e.getMessage());
 				e.printStackTrace();

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
@@ -809,6 +809,49 @@ public class MetadataFilesToEcho {
 		// No spatial extent exists for SWOT L0 data so set as global
 		setGranuleBoundingBox(90.0, -90.0, 180.0, -180.0);
 	}
+    
+    /**
+     * Parse metadata from SWOT Cal/Val XML file
+     * @param file path to SWOT Cal/Val XML file on local file system
+     */
+    public void readSwotCalValXmlFile(String file) throws ParserConfigurationException, IOException, SAXException,
+            XPathExpressionException {
+        DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
+        docBuilderFactory.setNamespaceAware(true);
+        DocumentBuilder docBuilder = docBuilderFactory.newDocumentBuilder();
+        Document doc = docBuilder.parse(new File(file));
+    
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        xpath.setNamespaceContext(new NamespaceResolver(doc));
+    
+        String startTime = xpath.evaluate(SwotCalValXmlPath.BEGINNING_DATE_TIME, doc);
+        String stopTime = xpath.evaluate(SwotCalValXmlPath.ENDING_DATE_TIME, doc);
+        String createTime = xpath.evaluate(SwotCalValXmlPath.CREATION_DATE_TIME, doc);
+    
+        String north = xpath.evaluate(SwotCalValXmlPath.NORTH_BOUNDING_COORDINATE, doc);
+        String south = xpath.evaluate(SwotCalValXmlPath.SOUTH_BOUNDING_COORDINATE, doc);
+        String east = xpath.evaluate(SwotCalValXmlPath.EAST_BOUNDING_COORDINATE, doc);
+        String west = xpath.evaluate(SwotCalValXmlPath.WEST_BOUNDING_COORDINATE, doc);
+    
+        try {
+            granule.setStartTime(DatatypeConverter.parseDateTime(startTime).getTime());
+            granule.setStopTime(DatatypeConverter.parseDateTime(stopTime).getTime());
+            granule.setCreateTime(DatatypeConverter.parseDateTime(createTime).getTime());
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException(String.format("Failed to parse datetime start=%s stop=%s create=%s",
+                    startTime, stopTime, createTime), exception);
+        }
+    
+        try {
+            setGranuleBoundingBox(Double.parseDouble(north),
+                    Double.parseDouble(south),
+                    Double.parseDouble(east),
+                    Double.parseDouble(west));
+        } catch (NullPointerException | NumberFormatException exception) {
+            throw new IllegalArgumentException(String.format("Failed to parse bbox N=%s S=%s E=%s W=%s", north, south,
+                    east, west), exception);
+        }
+    }
 
 	UMMGranule createSwotArchiveGranule(Document doc, XPath xpath)
 	throws XPathExpressionException{

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/SwotCalValXmlPath.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/SwotCalValXmlPath.java
@@ -1,0 +1,11 @@
+package gov.nasa.cumulus.metadata.aggregator;
+
+public class SwotCalValXmlPath extends IsoXPath {
+    public static final String BEGINNING_DATE_TIME = "/GranuleMetaDataFile/Extent/TemporalExtent/StartDateTime";
+    public static final String ENDING_DATE_TIME = "/GranuleMetaDataFile/Extent/TemporalExtent/EndDateTime";
+    public static final String CREATION_DATE_TIME = "/GranuleMetaDataFile/DataGranuleMembers[1]/DataGranuleMember/ProductionDateTime";
+    public static final String WEST_BOUNDING_COORDINATE = "/GranuleMetaDataFile/Extent/SpatialExtent/WestBoundLongitude";
+    public static final String SOUTH_BOUNDING_COORDINATE = "/GranuleMetaDataFile/Extent/SpatialExtent/SouthBoundLatitude";
+    public static final String EAST_BOUNDING_COORDINATE = "/GranuleMetaDataFile/Extent/SpatialExtent/EastBoundLongitude";
+    public static final String NORTH_BOUNDING_COORDINATE = "/GranuleMetaDataFile/Extent/SpatialExtent/NorthBoundLatitude";
+}

--- a/src/test/resources/SWOTCalVal_WM_ADCP_L0_RiverRay1_20220727T191701_20220727T192858_20220920T142800.xml
+++ b/src/test/resources/SWOTCalVal_WM_ADCP_L0_RiverRay1_20220727T191701_20220727T192858_20220920T142800.xml
@@ -1,0 +1,124 @@
+<GranuleMetaDataFile>
+   <!-- Project Name. Will always be set to SWOTCalVal -->
+   <Project>SWOTCalVal</Project>
+
+   <!-- Name of this XML file delivered with the data identified in this XML file, WITHOUT the .xml extension -->
+   <!-- Naming convention for this file is SWOTCalVal_campaignshortname_shortname_YYYYMMDDTHHMMSS_YYYYMMDDTHHMMSS.xml -->
+   <!-- Two time tags MUST correspond to value in StartDateTime and EndDateTime entries below within the metadata tags below-->
+   <!-- Include a Campaign short name below, and include that in the file names -->
+   <FileIdentifier>SWOTCalVal_WM_ADCP_L0_RiverRay1_20220727T191701_20220727T192858_20220920T142800</FileIdentifier>
+   <!-- Meta data for the referenced collection of data files -->
+   
+   <CollectionMetaData>
+      <Campaign>WillametteRiver</Campaign>
+      <CampaignShortName>WM</CampaignShortName>
+      <ShortName>ADCP_L0</ShortName>
+      <InstrumentName>RiverRay1</InstrumentName>
+      <Description>Acoustic Doppler Current Profiler raw data in instrument-specific format (.mmt and .pd0 for TRDI and .riv for Sontek instruments)</Description>
+   </CollectionMetaData>
+   
+   <Extent>
+      <TemporalExtent>
+         <StartDateTime>2022-07-27T19:17:01.000000Z</StartDateTime>
+         <EndDateTime>2022-07-27T19:28:58.000000Z</EndDateTime>
+      </TemporalExtent>
+      <SpatialExtent>
+         <WestBoundLongitude>-123.303833</WestBoundLongitude>
+         <EastBoundLongitude>-123.029268</EastBoundLongitude>
+         <SouthBoundLatitude>44.506438</SouthBoundLatitude>
+         <NorthBoundLatitude>44.697213</NorthBoundLatitude>
+      </SpatialExtent>
+   </Extent>
+
+   <!-- The DataGranuleMembers encompasses all of the DataGranule members -->
+   <!-- Each DataGranule member must refer to an individual file -->
+   <!-- Each DataGranule member must contain LocalGranuleID(=Filename), Checksum, ChecksumType, and Size -->
+   <!-- ProductDataTime is creation time of this file, and is optional -->
+   <!-- Ideally we want to keep 1 DataGranuleMember per metadata. -->
+   <!-- Otherwise, keep it to a maximum of 10 member. -->
+   <!-- Make the member a tarball to avoid exceeding 10 members. -->
+
+   <DataGranuleMembers>
+      <DataGranuleMember>
+         <!-- Include this XML file as a granule member, and it necessarily will NOT have an associated checksum -->
+         <LocalGranuleID>SWOTCalVal_WM_ADCP_L0_RiverRay1_20220727T191701_20220727T192858_20220920T142800.xml</LocalGranuleID>
+         <ProductionDateTime>2022-09-20T14:28:00.000000Z</ProductionDateTime>
+      </DataGranuleMember>
+      <DataGranuleMember>
+	  <!-- Every tarball contains 1 mmt and can contain multiple .pd0 files for a PT location, do we need to list what is in the tarball?-->
+         <LocalGranuleID>SWOTCalVal_WM_ADCP_L0_RiverRay1_20220727T191701_20220727T192858_20220920T142800.tar.gz</LocalGranuleID>
+         <ProductionDateTime>2022-09-20T14:28:00.000000Z</ProductionDateTime>
+         <Checksum>90a25208aa967bc7b0b8e669ab549de4</Checksum>
+         <ChecksumType>MD5</ChecksumType>
+         <Size>366165</Size>
+      </DataGranuleMember>
+   </DataGranuleMembers>
+
+   <!-- Additional metadata are most likely not captured by the DAAC but are available to the end user in this (XML) archive information package-->
+   <!-- Each campaign can choose additional metadata fields. May or may not be used by PODAAC, and will information generally not used for data searches -->
+   <Additional>
+      <Personnel>JTM</Personnel>
+      <Contact>tminear@colorado.edu</Contact>
+	  <ADCPModel>RiverRay</ADCPModel>
+      <ADCPSerial>2169</ADCPSerial>
+      <AntennaModel>Hemisphere A100</AntennaModel>
+      <IGSCalibration>NONE</IGSCalibration>
+      <Radome>NONE</Radome>
+      <AntennaSerial>12345</AntennaSerial>
+	  <TransducerDepth_m>0.080</TransducerDepth_m>
+	  <MagneticVariation>14.80</MagneticVariation>
+	  <!-- Either GNSS or BottomTracking -->
+	  <Positionmethod>Bottom Tracking</Positionmethod>
+	  <TransectLocation>PT003</TransectLocation>
+	  <!-- Each .pd0 file within the tarball is listed as an event, and associated .mmt is included --> 
+	  <TransectTypes>
+		<TransectType>
+			<Code>0</Code>
+			<Description>test</Description>
+		</TransectType>
+		<TransectType>
+			<Code>1</Code>
+			<Description>longitudinal profile</Description>
+		</TransectType>
+		<TransectType>
+			<Code>2</Code>
+			<Description>cross-section</Description>
+		</TransectType>
+	  </TransectTypes>
+      <Events>
+		  <Event>
+             <StartDateTime>2022-07-27T19:17:01.000000Z</StartDateTime>
+			 <MeasurementFile>wm_pt2.mmt</MeasurementFile>
+             <TransectFile>wm_pt2_008.PD0</TransectFile>
+			 <!-- RiverRight = RR, RiverLeft = RL, does this need to be explained above? -->
+			 <TransectStart>RL</TransectStart>
+			 <TransectEnd>RR</TransectEnd>
+			 <TransectType>2</TransectType>
+          </Event>
+		  <Event>
+             <StartDateTime>2022-07-27T19:21:03.000000Z</StartDateTime>
+			 <MeasurementFile>wm_pt2.mmt</MeasurementFile>
+             <TransectFile>wm_pt2_009.PD0</TransectFile>
+			 <TransectStart>RR</TransectStart>
+			 <TransectEnd>RL</TransectEnd>
+			 <TransectType>2</TransectType>
+          </Event>
+		  <Event>
+             <StartDateTime>2022-07-27T19:24:41.000000Z</StartDateTime>
+			 <MeasurementFile>wm_pt2.mmt</MeasurementFile>
+             <TransectFile>wm_pt2_010.PD0</TransectFile>
+             <TransectStart>RL</TransectStart>
+			 <TransectEnd>RR</TransectEnd>
+			 <TransectType>2</TransectType>
+          </Event>
+		  <Event>
+             <StartDateTime>2022-07-27T19:28:58.000000Z</StartDateTime>
+			 <MeasurementFile>wm_pt2.mmt</MeasurementFile>
+             <TransectFile>wm_pt2_011.PD0</TransectFile>
+             <TransectStart>RR</TransectStart>
+			 <TransectEnd>RL</TransectEnd>
+			 <TransectType>2</TransectType>
+          </Event>
+      </Events>
+   </Additional>
+</GranuleMetaDataFile>


### PR DESCRIPTION
SWOT Cal/Val is providing a new XML format we don't currently support. We should support this new format

* Updated code to support new format
* Ensured errors are handled gracefully -- if datetime cannot be parsed or string cannot be converted to double, we should raise a meaningful error and fail ingest.
* Added new unit test
