### PR TITLE
[PODAAC-5089-FIX] add in checker to force .png file to be type:browse

### DIFF
--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataAggregatorLambda.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataAggregatorLambda.java
@@ -89,18 +89,6 @@ public class MetadataAggregatorLambda implements ITask {
 		}
 
 		/*
-		Alter files ending with .png to have type:browse
-		 */
-		for (Object f : files) {
-			JSONObject file = (JSONObject) f;
-			String filename = (String) file.get("fileName");
-			if(filename.endsWith(".png")){
-				AdapterLogger.LogDebug("foundPNG - " + filename + "\nforcing type to be \"browse\"");
-				file.put("type", "browse");
-			}
-		}
-
-		/*
 		 * go through files and process if it's an .FP or an .MP
 		 */
 		//for(int i = 0; i< files.size(); i++){
@@ -119,6 +107,14 @@ public class MetadataAggregatorLambda implements ITask {
 			JSONObject file = (JSONObject) f;
 			String filename = (String) file.get("fileName");
 			String key = (String) file.get("key");
+
+			/*
+			Alter files ending with .png to have type:browse
+			 */
+			if(filename.endsWith(".png")){
+				AdapterLogger.LogDebug("foundPNG - " + filename + "\nforcing type to be \"browse\"");
+				file.put("type", "browse");
+			}
 
 			//String filename = file.getName();
 			if (filename.endsWith(".mp")) {

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataAggregatorLambda.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataAggregatorLambda.java
@@ -89,6 +89,18 @@ public class MetadataAggregatorLambda implements ITask {
 		}
 
 		/*
+		Alter files ending with .png to have type:browse
+		 */
+		for (Object f : files) {
+			JSONObject file = (JSONObject) f;
+			String filename = (String) file.get("fileName");
+			if(filename.endsWith(".png")){
+				AdapterLogger.LogDebug("foundPNG - " + filename + "\nforcing type to be \"browse\"");
+				file.put("type", "browse");
+			}
+		}
+
+		/*
 		 * go through files and process if it's an .FP or an .MP
 		 */
 		//for(int i = 0; i< files.size(); i++){


### PR DESCRIPTION
This is a potential fix in regards making PNG files visible on earthdata search by applying `"browse"` tag on .png files