### PR TITLE
Feature/PODAAC-5291: UMM-G metadata should order links correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+### Deprecated
+### Removed
+### Fixed
+- **PODAAC-5291**
+  - Assure the UMMG RelatedUrls arry in the following order
+    - http/https scientific data
+    - other http/https files
+    - s3 scientific data
+    - other s3 files
+### Security
+- Snyk: Security upgrade com.amazonaws:aws-java-sdk-s3 from 1.12.378 to 1.12.386
+
+
 ## [8.3.0]
 ### Added
 - **PODAAC-4748**

--- a/pom.xml
+++ b/pom.xml
@@ -44,13 +44,13 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.12.414</version>
+      <version>1.12.440</version>
     </dependency>
     <!-- For AWS Secret Manager -->
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-secretsmanager</artifactId>
-      <version>1.12.398</version>
+      <version>1.12.440</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
@@ -1051,6 +1051,7 @@ public class MetadataFilesToEcho {
 			throws IOException, ParseException, URISyntaxException{
 		JSONObject granuleJson = createJson();
         JSONUtils.cleanJSON(granuleJson);
+		granuleJson = JSONUtils.sortRelatedUrls(granuleJson);
         FileUtils.writeStringToFile(new File(outputLocation), granuleJson.toJSONString());
 	}
 

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/ImageProcessor.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/ImageProcessor.java
@@ -83,12 +83,13 @@ public class ImageProcessor extends ProcessorBase{
             // first split relatedUrls to 2 arrays, one including http/https resources and
             // the other array contain items which are NOT http/https resources
             JsonArray httpArray = new JsonArray();
-            JsonArray otherArray = new JsonArray();
+            JsonArray otherItemsArray = new JsonArray();
+            String[] httpStrs = {"http", "https"};
             relatedUrls.forEach(e -> {
-                if(JSONUtils.isStartingWithHttpHttps(((JsonObject)e).getAsString())) {
+                if(JSONUtils.isStrStarsWithIgnoreCase(e.getAsJsonObject().get("URL").getAsString(), httpStrs)) {
                     httpArray.add(e);
                 } else {
-                    otherArray.add(e);
+                    otherItemsArray.add(e);
                 }
             });
             for (JsonElement f : files) {
@@ -111,7 +112,7 @@ public class ImageProcessor extends ProcessorBase{
                 }
             }
             // now add all elements from the other array into the end of the httpArray
-            otherArray.forEach(e -> httpArray.add(e)); // now httpArray has everything, http, http-image and non-http resources
+            otherItemsArray.forEach(e -> httpArray.add(e)); // append otherItmesArray on the end of httpArray
             cmrJsonObj.add("RelatedUrls", httpArray);
             String newCMRStr = gsonBuilder.toJson(cmrJsonObj);
             return newCMRStr;

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/ImageProcessor.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/processor/ImageProcessor.java
@@ -3,6 +3,7 @@ package gov.nasa.cumulus.metadata.aggregator.processor;
 import com.google.gson.*;
 import cumulus_message_adapter.message_parser.AdapterLogger;
 import gov.nasa.cumulus.metadata.umm.generated.RelatedUrlType;
+import gov.nasa.cumulus.metadata.util.JSONUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 
@@ -33,7 +34,7 @@ public class ImageProcessor extends ProcessorBase{
             this.region = region;
             decodeVariables(input);
             this.workingDir = createWorkDir();
-            String newCMRStr = appendImageUrl(input, ummgStr);
+            String newCMRStr = appendImageUrls(input, ummgStr);
             String cmrFileName = buildCMRFileName(this.granuleId, this.executionId);
             long cmrFileSize = uploadCMRJson(cmrBucket, cmrDir, this.collectionName, cmrFileName,
                     newCMRStr);
@@ -53,16 +54,15 @@ public class ImageProcessor extends ProcessorBase{
         }
     }
 
-    public String appendImageUrl(String input, String cmrString)
+    public String appendImageUrls(String input, String cmrString)
             throws IOException, URISyntaxException {
         try {
             Gson gsonBuilder = getGsonBuilder();
             JsonObject cmrJsonObj = JsonParser.parseString(cmrString).getAsJsonObject();
             JsonArray relatedUrls = cmrJsonObj.getAsJsonArray("RelatedUrls");
-            // If cmrJson does not included relatedURLs jsonArray, then create one and then attached to cmrJsonObj
+            // If cmrJson does not include relatedURLs jsonArray, then create one and then attached to cmrJsonObj
             if (relatedUrls == null) {
                 relatedUrls = new JsonArray();
-                cmrJsonObj.add("RelatedUrls", relatedUrls);
             }
 
             JsonObject inputJsonObj = JsonParser.parseString(input).getAsJsonObject();
@@ -74,7 +74,23 @@ public class ImageProcessor extends ProcessorBase{
 
             files = granule.get("files").getAsJsonArray();
             JsonArray files = granule.get("files").getAsJsonArray();
-
+            /*  At this point, the RelatedUrls array has been sorted with
+                http/https scientific data
+                other http files
+                s3 scientific data
+                other s3 file
+             */
+            // first split relatedUrls to 2 arrays, one including http/https resources and
+            // the other array contain items which are NOT http/https resources
+            JsonArray httpArray = new JsonArray();
+            JsonArray otherArray = new JsonArray();
+            relatedUrls.forEach(e -> {
+                if(JSONUtils.isStartingWithHttpHttps(((JsonObject)e).getAsString())) {
+                    httpArray.add(e);
+                } else {
+                    otherArray.add(e);
+                }
+            });
             for (JsonElement f : files) {
                 JsonObject fileObj = f.getAsJsonObject();
                 String filename = StringUtils.trim(f.getAsJsonObject().get("fileName").getAsString());
@@ -89,10 +105,14 @@ public class ImageProcessor extends ProcessorBase{
                         relatedUrlType.setMimeType(getImageMimeType(filename));
 
                         String relatedUrlTypeStr = gsonBuilder.toJson(relatedUrlType);
-                        relatedUrls.add(JsonParser.parseString(relatedUrlTypeStr));
+                        // append image Url to the end of the http array which has all http/https resources
+                        httpArray.add(JsonParser.parseString(relatedUrlTypeStr));
                     }
                 }
             }
+            // now add all elements from the other array into the end of the httpArray
+            otherArray.forEach(e -> httpArray.add(e)); // now httpArray has everything, http, http-image and non-http resources
+            cmrJsonObj.add("RelatedUrls", httpArray);
             String newCMRStr = gsonBuilder.toJson(cmrJsonObj);
             return newCMRStr;
         } catch (URISyntaxException ipe) {

--- a/src/main/java/gov/nasa/cumulus/metadata/util/JSONUtils.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/util/JSONUtils.java
@@ -207,10 +207,7 @@ public class JSONUtils {
      */
     public static boolean isStrStarsWithIgnoreCase(String s, String startStr) {
         s = StringUtils.trim(s);
-        if(StringUtils.startsWithIgnoreCase(s,startStr)) {
-            return true;
-        }
-        return false;
+        return StringUtils.startsWithIgnoreCase(s,startStr);
     }
 
     /**

--- a/src/main/java/gov/nasa/cumulus/metadata/util/JSONUtils.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/util/JSONUtils.java
@@ -231,10 +231,7 @@ public class JSONUtils {
 
     public static boolean isGETDataType(String s) {
         s = StringUtils.trim(s);
-        if(StringUtils.equalsIgnoreCase(s,RelatedUrlType.RelatedUrlTypeEnum.GET_DATA.value()) ) {
-            return true;
-        }
-        return false;
+        return StringUtils.equalsIgnoreCase(s,RelatedUrlType.RelatedUrlTypeEnum.GET_DATA.value());
     }
 
 

--- a/src/main/java/gov/nasa/cumulus/metadata/util/JSONUtils.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/util/JSONUtils.java
@@ -133,11 +133,12 @@ public class JSONUtils {
         JSONArray sortedRelatedUrls = new JSONArray();
         ArrayList<JSONObject> toBeRemovedItems = new ArrayList<>();
         // first, extract URL starts with http/https and Type == GET DATA to added into sortedRelatedUrls
+        String[] httpStrs = {"http", "https"};
         for(int i =0; i< unsortedRelatedUrls.size(); i++) {
             JSONObject relatedUrl = (JSONObject) unsortedRelatedUrls.get(i);
-            if( isStartingWithHttpHttps((String)relatedUrl.get("URL"))
+            if( isStrStarsWithIgnoreCase((String)relatedUrl.get("URL"),httpStrs)
                     &&
-                    isGETTYPE((String)relatedUrl.get("Type"))
+                    isGETDataType((String)relatedUrl.get("Type"))
                  ) {
                 sortedRelatedUrls.add(relatedUrl);
                 toBeRemovedItems.add(relatedUrl);
@@ -149,7 +150,7 @@ public class JSONUtils {
         // other http/https files
         for(int i =0; i< unsortedRelatedUrls.size(); i++) {
             JSONObject relatedUrl = (JSONObject) unsortedRelatedUrls.get(i);
-            if(isStartingWithHttpHttps((String)relatedUrl.get("URL"))) {
+            if(isStrStarsWithIgnoreCase((String)relatedUrl.get("URL"),httpStrs)) {
                 sortedRelatedUrls.add(relatedUrl);
                 toBeRemovedItems.add(relatedUrl);
             }
@@ -160,9 +161,9 @@ public class JSONUtils {
         // s3 link to scientific data
         for(int i =0; i< unsortedRelatedUrls.size(); i++) {
             JSONObject relatedUrl = (JSONObject) unsortedRelatedUrls.get(i);
-            if(isGETTYPE((String)relatedUrl.get("Type"))
+            if(isGETDataType((String)relatedUrl.get("Type"))
                 &&
-                    isStartingWithS3((String)relatedUrl.get("URL"))) {
+                    isStrStarsWithIgnoreCase((String)relatedUrl.get("URL"), "s3://")) {
                 sortedRelatedUrls.add(relatedUrl);
                 toBeRemovedItems.add(relatedUrl);
             }
@@ -172,7 +173,7 @@ public class JSONUtils {
         // other s3 links
         for(int i =0; i< unsortedRelatedUrls.size(); i++) {
             JSONObject relatedUrl = (JSONObject) unsortedRelatedUrls.get(i);
-            if(isStartingWithS3((String)relatedUrl.get("URL"))) {
+            if(isStrStarsWithIgnoreCase((String)relatedUrl.get("URL"), "s3://")) {
                 sortedRelatedUrls.add(relatedUrl);
                 toBeRemovedItems.add(relatedUrl);
             }
@@ -198,23 +199,37 @@ public class JSONUtils {
         return unsortedRelatedUrls;
     }
 
-    public static boolean isStartingWithHttpHttps(String s) {
+    /**
+     *
+     * @param s   : The string to be verified
+     * @param startStr : verifies the input s is starting with startStr ignoring case
+     * return  true/false
+     */
+    public static boolean isStrStarsWithIgnoreCase(String s, String startStr) {
         s = StringUtils.trim(s);
-        if(StringUtils.startsWithIgnoreCase(s,"http://") || StringUtils.startsWithIgnoreCase(s,"https://")) {
+        if(StringUtils.startsWithIgnoreCase(s,startStr)) {
             return true;
         }
         return false;
     }
 
-    public static boolean isStartingWithS3(String s) {
+    /**
+     *
+     * @param s: The string to be verified
+     * @param startStrs: verifies the input s is starting with at least one item in startStrs[] ignoring case
+     * @return true/false
+     */
+    public static boolean isStrStarsWithIgnoreCase(String s, String[] startStrs) {
         s = StringUtils.trim(s);
-        if(StringUtils.startsWithIgnoreCase(s,"s3://") ) {
-            return true;
+        for(String elementStr:startStrs) {
+            if(StringUtils.startsWithIgnoreCase(s, elementStr)){
+                return true;
+            }
         }
         return false;
     }
 
-    public static boolean isGETTYPE(String s) {
+    public static boolean isGETDataType(String s) {
         s = StringUtils.trim(s);
         if(StringUtils.equalsIgnoreCase(s,RelatedUrlType.RelatedUrlTypeEnum.GET_DATA.value()) ) {
             return true;

--- a/src/test/java/gov/nasa/cumulus/metadata/test/ImageProcessorTest.java
+++ b/src/test/java/gov/nasa/cumulus/metadata/test/ImageProcessorTest.java
@@ -145,7 +145,7 @@ public class ImageProcessorTest {
     @Test
     public void testIsDownloadUrlAlreadyExist() {
         ImageProcessor imageProcessor = new ImageProcessor();
-        JsonObject cmrJsonObj = new JsonParser().parse(cmrString).getAsJsonObject();
+        JsonObject cmrJsonObj = JsonParser.parseString(cmrString).getAsJsonObject();
         JsonArray relatedUrls = cmrJsonObj.getAsJsonArray("RelatedUrls");
         boolean isAlreadyExist = imageProcessor.isDownloadUrlAlreadyExist(relatedUrls,
                 "https://jh72u371y2.execute-api.us-west-2.amazonaws.com:9000/DEV/dyen-cumulus-public/MODIS_A-JPL-L2P-v2019.0/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.sses_standard_deviation.png");

--- a/src/test/java/gov/nasa/cumulus/metadata/test/ImageProcessorTest.java
+++ b/src/test/java/gov/nasa/cumulus/metadata/test/ImageProcessorTest.java
@@ -76,10 +76,10 @@ public class ImageProcessorTest {
         try {
             ImageProcessor imageProcessor = new ImageProcessor();
             String downloadUri = imageProcessor.getImageDownloadUrl("https://distribution/xxx/bb/download",
-                    "my-public-bucket","/collection_name/granuleId/Image1.jpg");
+                    "my-public-bucket", "/collection_name/granuleId/Image1.jpg");
             assertEquals(downloadUri,
                     "https://distribution/xxx/bb/download/my-public-bucket/collection_name/granuleId/Image1.jpg");
-        } catch  (URISyntaxException uriSyntaxException) {
+        } catch (URISyntaxException uriSyntaxException) {
             System.out.println(uriSyntaxException);
             fail();
         }
@@ -88,19 +88,18 @@ public class ImageProcessorTest {
     /**
      * This test purposely make getImageDownloadUrl throwing URISyntaxException
      * by passing illegal character '^' as distribution_url.
-     *
+     * <p>
      * fail() will force the test case to fail. Since the test is to force URISyntaxException
      * to be thrown, it is a failed case if not thrown.
-     *
      */
     @Test
     public void testGetImageDownloadUrl_URISyntaxException() {
         try {
             ImageProcessor imageProcessor = new ImageProcessor();
             String downloadUri = imageProcessor.getImageDownloadUrl("https://distribution/xxx/bb/download^12334",
-                    "my-public-bucket","s3://my-public-bucket/collection_name/granuleId/image1.jpg");
+                    "my-public-bucket", "s3://my-public-bucket/collection_name/granuleId/image1.jpg");
             fail();
-        } catch  (URISyntaxException uriSyntaxException) {
+        } catch (URISyntaxException uriSyntaxException) {
             assertTrue(true);
         }
     }
@@ -116,7 +115,7 @@ public class ImageProcessorTest {
              *      "s3://dyen-cumulus-public/dataset-image/MODIS_A-JPL-L2P-v2019.0/standard-deviation.jpg",
              */
             ImageProcessor imageProcessor = new ImageProcessor();
-            String newCMRStr = imageProcessor.appendImageUrl(cmaString, cmrString);
+            String newCMRStr = imageProcessor.appendImageUrls(cmaString, cmrString);
             JsonObject cmrJsonObj = JsonParser.parseString(newCMRStr).getAsJsonObject();
             JsonArray relatedUrls = cmrJsonObj.getAsJsonArray("RelatedUrls");
             int count = findTimesOfAppearance(relatedUrls,
@@ -138,7 +137,7 @@ public class ImageProcessorTest {
         downloadUrl = StringUtils.trim(downloadUrl);
         for (JsonElement relatedUrl : relatedUrls) {
             String ummg_downloadUrl = StringUtils.trim(relatedUrl.getAsJsonObject().get("URL").getAsString());
-            if(StringUtils.compare(ummg_downloadUrl, downloadUrl) ==0) count ++;
+            if (StringUtils.compare(ummg_downloadUrl, downloadUrl) == 0) count++;
         }
         return count;
     }
@@ -162,19 +161,19 @@ public class ImageProcessorTest {
     @Test
     public void testCreateOutputMessage() {
         ImageProcessor processor = new ImageProcessor();
-        String output =  processor.createOutputMessage(cmaString, 334411,
+        String output = processor.createOutputMessage(cmaString, 334411,
                 new BigInteger("3244"), "granuleId-3344-22.cmr.json", "my-private",
                 "CMR", "collectionName");
         JsonElement jsonElement = JsonParser.parseString(output);
         JsonArray granules = jsonElement.getAsJsonObject().get("output").getAsJsonArray();
         JsonArray files = granules.get(0).getAsJsonObject().get("files").getAsJsonArray();
 
-        JsonObject foundCMR =  processor.getFileJsonObjByFileTrailing(files, ".cmr.json");
+        JsonObject foundCMR = processor.getFileJsonObjByFileTrailing(files, ".cmr.json");
         assertEquals(foundCMR.get("bucket").getAsString(), "my-private");
         assertEquals(foundCMR.get("key").getAsString(), "CMR/collectionName/granuleId-3344-22.cmr.json");
         assertEquals(foundCMR.get("fileName").getAsString(), "granuleId-3344-22.cmr.json");
-        Long  cmrFileSize =  foundCMR.get("size").getAsLong();
-        BigInteger  revisionId =  jsonElement.getAsJsonObject().get("cmrRevisionId").getAsBigInteger();
+        Long cmrFileSize = foundCMR.get("size").getAsLong();
+        BigInteger revisionId = jsonElement.getAsJsonObject().get("cmrRevisionId").getAsBigInteger();
         assertEquals(334411, cmrFileSize.longValue());
         assertEquals(revisionId.compareTo(new BigInteger("3244")), 0);
     }

--- a/src/test/java/gov/nasa/cumulus/metadata/test/JSONUtilsTest.java
+++ b/src/test/java/gov/nasa/cumulus/metadata/test/JSONUtilsTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 
 
@@ -16,6 +17,7 @@ import gov.nasa.cumulus.metadata.util.JSONUtils;
 import org.apache.commons.io.FileUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.junit.Test;
 
@@ -39,6 +41,55 @@ public class JSONUtilsTest {
         JSONObject dataGranule = (JSONObject)translatedSimpleJsonObj.get("DataGranule");
         String productionDateTime = (String)dataGranule.get("ProductionDateTime");
         assertEquals(productionDateTime, "2020-02-29T12:20:15.000Z");
+    }
+
+    @Test
+    public void testIsStartingWithHttpHttps() throws IOException, ParseException{
+        assertEquals(JSONUtils.isStartingWithHttpHttps("http://aabbcc"), true);
+        assertEquals(JSONUtils.isStartingWithHttpHttps("https://myresourc.com"), true);
+        //test with space
+        assertEquals(JSONUtils.isStartingWithHttpHttps(" http://mm.ee.com "), true);
+        assertEquals(JSONUtils.isStartingWithHttpHttps(" https://mm.com/resource  "), true);
+
+        // test false condition
+        assertEquals(JSONUtils.isStartingWithHttpHttps(" htt:p:// "), false);
+        assertEquals(JSONUtils.isStartingWithHttpHttps(" https;//  "), false);
+    }
+    @Test
+    public void testIsStartingWithS3() throws IOException, ParseException{
+        assertEquals(JSONUtils.isStartingWithS3("s3://mybucket/myfolder/file.txt"), true);
+        //test with space
+        assertEquals(JSONUtils.isStartingWithS3(" s3://mybucket/myfolder/file.txt "), true);
+
+        // test false condition
+        assertEquals(JSONUtils.isStartingWithS3(" s3:p://mybucket/myfolder/file.txt "), false);
+        assertEquals(JSONUtils.isStartingWithS3(" s3;//mybucket/myfolder/file.txt  "), false);
+    }
+    @Test
+    public void testIsGETTYPE() throws IOException, ParseException {
+        assertEquals(JSONUtils.isGETTYPE("GET DATA"), true);
+        assertEquals(JSONUtils.isGETTYPE(" GET DATA "), true);
+        assertEquals(JSONUtils.isGETTYPE(" Get data "), true);
+        //test with space
+        assertEquals(JSONUtils.isStartingWithS3(" GEET Type "), false);
+    }
+
+    @Test
+    public void testSorting() throws  ParseException{
+        String cmr_filename= "20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0-unsortedUrls.cmr.json";
+        try {
+            ClassLoader classLoader = getClass().getClassLoader();
+            File inputCMRJsonFile = new File(classLoader.getResource(cmr_filename).getFile());
+            String cmrString = new String(Files.readAllBytes(inputCMRJsonFile.toPath()));
+            JSONParser parser = new JSONParser();
+            JSONObject json = (JSONObject) parser.parse(cmrString);
+            json = JSONUtils.sortRelatedUrls(json);
+            //TODO check sorted result
+            assertEquals(true, true);
+        } catch (IOException ioe) {
+            System.out.println("Test initialization failed: " + ioe);
+            ioe.printStackTrace();
+        }
     }
 
 }

--- a/src/test/resources/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0-unsortedUrls.cmr.json
+++ b/src/test/resources/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0-unsortedUrls.cmr.json
@@ -1,0 +1,108 @@
+{
+  "TemporalExtent": {
+    "RangeDateTime": {
+      "EndingDateTime": "2020-01-01T00:04:57.000Z",
+      "BeginningDateTime": "2020-01-01T00:00:00.000Z"
+    }
+  },
+  "MetadataSpecification": {
+    "Version": "1.6",
+    "URL": "https://cdn.earthdata.nasa.gov/umm/granule/v1.6",
+    "Name": "UMM-G"
+  },
+  "GranuleUR": "20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0",
+  "ProviderDates": [
+    {
+      "Type": "Insert",
+      "Date": "2020-07-17T23:10:21.470Z"
+    },
+    {
+      "Type": "Update",
+      "Date": "2020-07-17T23:10:21.484Z"
+    }
+  ],
+  "SpatialExtent": {
+    "HorizontalSpatialDomain": {
+      "Geometry": {
+        "BoundingRectangles": [
+          {
+            "WestBoundingCoordinate": 123.165,
+            "SouthBoundingCoordinate": -89.989,
+            "EastBoundingCoordinate": 180,
+            "NorthBoundingCoordinate": -66.906
+          },
+          {
+            "WestBoundingCoordinate": -180,
+            "SouthBoundingCoordinate": -89.989,
+            "EastBoundingCoordinate": -74.116,
+            "NorthBoundingCoordinate": -66.906
+          }
+        ]
+      }
+    }
+  },
+  "DataGranule": {
+    "ArchiveAndDistributionInformation": [
+      {
+        "SizeUnit": "MB",
+        "Size": 17.387483596801758,
+        "Name": "20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc"
+      }
+    ],
+    "DayNightFlag": "Unspecified",
+    "ProductionDateTime": "2020-02-29T12:20:15.000Z"
+  },
+  "CollectionReference": {
+    "Version": "2019.0",
+    "ShortName": "MODIS_A-JPL-L2P-v2019.0"
+  },
+  "RelatedUrls": [
+    {
+      "URL": "https://vtdmnpv139.execute-api.us-west-2.amazonaws.com:9000/DEV/dyen-cumulus-public/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc.md5",
+      "Description": "File to download",
+      "Type": "EXTENDED METADATA"
+    },
+    {
+      "URL": "https://vtdmnpv139.execute-api.us-west-2.amazonaws.com:9000/DEV/dyen-cumulus-protected/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc",
+      "Description": "The base directory location for the granule.",
+      "Type": "GET DATA"
+    },
+    {
+      "URL": "s3://my-bucket/folder/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc",
+      "Description": "The base directory location for the granule.",
+      "Type": "GET DATA"
+    },
+    {
+      "URL": "https://vtdmnpv139.execute-api.us-west-2.amazonaws.com:9000/DEV/dyen-cumulus-public/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.cmr.json",
+      "Description": "File to download",
+      "Type": "EXTENDED METADATA"
+    },
+    {
+      "URL": "https://vtdmnpv139.execute-api.us-west-2.amazonaws.com:9000/DEV/s3credentials",
+      "Description": "api endpoint to retrieve temporary credentials valid for same-region direct s3 access",
+      "Type": "VIEW RELATED INFORMATION"
+    },
+    {
+      "URL": "https://opendap.uat.earthdata.nasa.gov/providers/POCUMULUS/collections/GHRSST%20Level%202P%20Global%20Sea%20Surface%20Skin%20Temperature%20from%20the%20Moderate%20Resolution%20Imaging%20Spectroradiometer%20(MODIS)%20on%20the%20NASA%20Aqua%20satellite%20(GDS2)/granules/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0",
+      "Type": "GET DATA",
+      "Subtype": "OPENDAP DATA",
+      "Description": "OPeNDAP request URL"
+    },
+    {
+      "URL": "https://jh72u371y2.execute-api.us-west-2.amazonaws.com:9000/DEV/dyen-cumulus-public/MODIS_A-JPL-L2P-v2019.0/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.sses_standard_deviation.png",
+      "Type": "GET RELATED VISUALIZATION",
+      "Subtype": "DIRECT DOWNLOAD",
+      "MimeType": "image/png"
+    },
+    {
+      "URL": "s3://my-bucket/folder/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc.md5",
+      "Description": "The base directory location for the granule.",
+      "Type": "EXTENDED METADATA"
+    },
+    {
+      "URL": "s3://my-bucket/folder/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.iso.xml",
+      "Description": "The base directory location for the granule.",
+      "Type": "EXTENDED METADATA"
+    }
+  ]
+}

--- a/src/test/resources/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0-unsortedUrls.cmr.json
+++ b/src/test/resources/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0-unsortedUrls.cmr.json
@@ -84,7 +84,7 @@
     },
     {
       "URL": "https://opendap.uat.earthdata.nasa.gov/providers/POCUMULUS/collections/GHRSST%20Level%202P%20Global%20Sea%20Surface%20Skin%20Temperature%20from%20the%20Moderate%20Resolution%20Imaging%20Spectroradiometer%20(MODIS)%20on%20the%20NASA%20Aqua%20satellite%20(GDS2)/granules/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0",
-      "Type": "GET DATA",
+      "Type": "USE SERVICE API",
       "Subtype": "OPENDAP DATA",
       "Description": "OPeNDAP request URL"
     },


### PR DESCRIPTION
Ticket: PODAAC-5291

### Description

Sort the item within ummg.RelatedUrls[] by following the rule of :
The HTTPs link of the primary science file.
The HTTPs links of all other files.
The S3 link of the primary science file.
The S3 links of all the other files.
### Overview of work done

### Overview of verification done

unit testing.

Integration testing by ingesting MODIS_A : 20200101234000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0
Before the code change, RelatedUrls:[] item sequence was random.  Especially, image links (.png) are appended in the end of the array.    So below are the before and after of code change:


Before the code enhancement, the RelatedUrls are Not sorted according to the acceptance criteria:
![image](https://user-images.githubusercontent.com/10672727/229931340-84830781-78ae-4135-ab62-46a2b7e0d5c5.png)

After the code enhancement. here is the relatedUrls

![image](https://user-images.githubusercontent.com/10672727/229876509-bcf7cd0a-3568-4572-b9ce-50ae8b7682da.png)


#### Tested in SIT:

_Explain how you tested in SIT, if applicable_

## PR checklist:

* [ ] Linted
* [x] Unit tests
* [ ] Addressed Snyk vulnerabilities
* [x] Updated changelog
* [ ] Tested in SIT
* [ ] Documentation / User-Guide Updated

_See [Pull Request Review Checklist](https://wiki.earthdata.nasa.gov/display/PCESA/Pull+Request+Review+Checklist) for pointers on reviewing this pull request_
