### PR TITLE
PODAAC-5614: strip leading zeros from cycle and pass in validity check

### DIFF
--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
@@ -916,8 +916,8 @@ public class MetadataFilesToEcho {
 		on the other hand, any exceptions caused by cycle or pass should be thrown all the way up and break the ingestion
 		 */
 		try {
-			if (NumberUtils.createInteger(StringUtils.trim(cycleStr)) == null ||
-					NumberUtils.createInteger(StringUtils.trim(passStr)) == null) {
+			if (NumberUtils.createInteger(UMMUtils.removeStrLeadingZeros(StringUtils.trim(cycleStr))) == null ||
+					NumberUtils.createInteger(UMMUtils.removeStrLeadingZeros(StringUtils.trim(passStr))) == null) {
 				return null;
 			}
 		} catch(NumberFormatException nfe) { // if either cycle or pass are un-processable, then return null

--- a/src/test/java/gov/nasa/cumulus/metadata/test/MetadataFilesToEchoTest.java
+++ b/src/test/java/gov/nasa/cumulus/metadata/test/MetadataFilesToEchoTest.java
@@ -401,6 +401,33 @@ public class MetadataFilesToEchoTest {
         List<AdditionalAttributeType> additionalAttributeTypes = isoGranule.getAdditionalAttributeTypes();
         assertEquals(additionalAttributeTypes.size(), 0);
     }
+    
+        @Test
+    public void testReadSwotArchoveMetadataFile_Pass_Cycle_LeadingZeros() throws IOException, ParseException, XPathExpressionException, ParserConfigurationException, SAXException{
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("SWOT_INT_KCAL_Dyn_403_008_20230117T150452_20230117T155629_PIA0_01.archive.xml").getFile());
+        File cfgFile = new File(classLoader.getResource("MODIS_T-JPL-L2P-v2014.0.cmr.cfg").getFile());
+        MetadataFilesToEcho mfte = new MetadataFilesToEcho(true);
+
+        Document doc = null;
+        XPath xpath = null;
+        mfte.readConfiguration(cfgFile.getAbsolutePath());
+        doc = mfte.makeDoc(file.getAbsolutePath());
+        xpath = mfte.makeXpath(doc);
+        mfte.readSwotArchiveXmlFile(file.getAbsolutePath());
+        UMMGranule granule = (UMMGranule) mfte.getGranule();
+        // Verify the values here:
+        TrackType trackType = granule.getTrackType();
+        assertEquals(trackType.getCycle(), new Integer(403));
+        List<TrackPassTileType> trackPassTileTypes = trackType.getPasses();
+        assertEquals(trackPassTileTypes.size(), 1);
+        TrackPassTileType trackPassTileType = trackPassTileTypes.get(0);
+        assertEquals(trackPassTileType.getPass(), new Integer(8));
+        List<String> tiles = trackPassTileType.getTiles();
+        assertEquals(tiles.size(), 1);
+        List<AdditionalAttributeType> additionalAttributeTypes = granule.getAdditionalAttributeTypes();
+        assertEquals(additionalAttributeTypes.size(), 1);
+    }
 
     @Test
     public void testReadIsoMendsMetadataFileAdditionalFields_publishAll() throws ParseException, IOException, URISyntaxException, XPathExpressionException, ParserConfigurationException, SAXException {

--- a/src/test/resources/SWOT_INT_KCAL_Dyn_403_008_20230117T150452_20230117T155629_PIA0_01.archive.xml
+++ b/src/test/resources/SWOT_INT_KCAL_Dyn_403_008_20230117T150452_20230117T155629_PIA0_01.archive.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ..................................................................................
+        Copyright (c) <2022>, California Institute of Technology ("Caltech")_ U.S. Government sponsorship acknowledged.
+        All rights reserved.
+        This document has been reviewed and determined not to contain export controlled technical data.
+   -->
+<!-- Reference Document .................................................................
+      metadata_archive_template_v3.xml.jinja2:
+         Based on example file from D-101950_SWOT_PGE_PCM_ICS_L0B_HR_FRAME_RevA(draft v2)_20220314b 4ECR.docx 
+   -->
+<!-- Definition .........................................................................
+        Archive Data Package:
+        = the data package delivered to DAAC has multiple categories: single data file, a list of files, tar-ed file
+        = For the tar-ed data package, this Archive-Only metadata file may or may be not included in the tar-ed file
+        = depending on the production scenario.
+        = When this file is included in the tar file, some informatioin in this file may be incomplete
+        Granule, aka, Dataset
+        = [1] (required)
+        = one file or a set of files that constitute a single data product
+        = It is further categorized into a prime [science] data file and the supporting files that are members of the granule
+        = e.g., a granule may be composed of ProductID.nc, ProductID.nc.iso.xml, ProductID.nc.met, ProductID.rc.xml, ProductID.png, etc
+        GranuleID
+        = File name of the prime [science] data file
+        = e.g., ProductID.nc is the GrauleID in the above example
+        Member of the Granule
+        = [0 ... n (optional)]
+        = The rest of the files that support the prime science data file, if the Granule is composed of multiple files
+        = There may be 0 to many member files
+    SourceType
+    = Defines the venue the data is generated
+    = O=operations, T=test, S=simulation
+    Off-nominal attribute values
+    = "unknown": when a value of an attribute is expected but PGE cannot determine what value to use or
+                 when a value of an attribute is not applicable to the current product type
+   -->
+<GranuleMetaDataFile>
+   <Project>test</Project>
+   <!-- FileIdentifier: Name of the data package delivered to DAAC: either the expected tar file or a prime science data file name, if not tar-ed
+      It is okay not to have “.tar.gz” in the value, particularly if it is not known to the PGE at the time of archive.xml file generation
+ -->
+   <FileIdentifier>SWOT_INT_KCAL_Dyn_403_008_20230117T150452_20230117T155629_PIA0_01.nc</FileIdentifier>
+   <GranuleURMetaData>
+      <CollectionMetaData>
+         <ShortName>test</ShortName>
+         <Description>test</Description>
+         <!-- VersionID = equivalent to SMAP's SeriesID: Determined in advance by ADT/MS CCB -->
+         <VersionID>test</VersionID>
+      </CollectionMetaData>
+      <!-- List the Prime Data File only -->
+      <ECSDataGranule>
+         <LocalGranuleID>SWOT_INT_KCAL_Dyn_403_008_20200117T000000_20200117T000000_PIA0_01.nc</LocalGranuleID>
+         <ProductionDateTime>2020-01-18T11:16:35.056934Z</ProductionDateTime>
+         <SourceType>unknown</SourceType>
+         <APID>1075</APID>
+         <CRID>PIA0</CRID>
+         <ProductCounter>01</ProductCounter>
+         <Description>Size: 123456789 SizeUnit: B</Description>
+         <CycleID>403</CycleID>
+         <PassID>008</PassID>
+         <TileID>unknown</TileID>
+      </ECSDataGranule>
+      <MemberOfECSDataGranule>
+         <LocalGranuleID>SWOT_INT_KCAL_Dyn_403_008_20200117T000000_20200117T000000_PIA0_01.met.json</LocalGranuleID>
+         <Description>Size: 123 SizeUnit: B</Description>
+      </MemberOfECSDataGranule>
+      <MemberOfECSDataGranule>
+         <LocalGranuleID>SWOT_INT_KCAL_Dyn_403_008_20200117T000000_20200117T000000_PIA0_01.rc.xml</LocalGranuleID>
+         <Description>Size: 4567 SizeUnit: B</Description>
+      </MemberOfECSDataGranule>
+      <MemberOfECSDataGranule>
+         <LocalGranuleID>SWOT_INT_KCAL_Dyn_403_008_20200117T000000_20200117T000000_PIA0_01.log</LocalGranuleID>
+         <Description>Size: unknown SizeUnit: B</Description>
+      </MemberOfECSDataGranule>
+      <MemberOfECSDataGranule>
+         <LocalGranuleID>SWOT_INT_KCAL_Dyn_403_008_20200117T000000_20200117T000000_PIA0_01.archive.xml</LocalGranuleID>
+         <Description>Size: unknown SizeUnit: B</Description>
+      </MemberOfECSDataGranule>
+      <RangeDateTime>
+         <RangeBeginningDateTime>2020-01-17T15:04:58.187000Z</RangeBeginningDateTime>
+         <RangeEndingDateTime>2020-01-17T15:56:23.716000Z</RangeEndingDateTime>
+      </RangeDateTime>
+      <Producer>test</Producer>
+      <AccessPermission>test</AccessPermission>
+      <!-- When a granile/dataset is composed of multiple files, list members of data package -->
+   </GranuleURMetaData>
+</GranuleMetaDataFile>


### PR DESCRIPTION
A while back a bugfix was implemented to address the leading zero issue with cycle/pass that resulted in the value being converted to octal. That fix has been working well, but we found one spot where this change is missing and causes issues for any granule where the cycle or pass contains invalid octal characters (8 or 9). In those cases, the validity check (see diff) raises an exception, so the cycle/pass extraction processing does not occur. 

In this PR, I've added the `UMMUtils.removeStrLeadingZeros` call around the cycle and pass in the validity check as well. Also added a unit test. 

Note; this has not yet been tested in a full Cumulus end-to-end test. 