### PR TITLE
re-generate using ummg 1.6.5 --target-version 1.11 for java classes c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PODAAC-5876**
   - Update to use CMA 2.0.0, thus allowing 2.0.3 layer for lambda
   - Update build to use java 11
+  - To generate java 11 compatible UMMG schema POJOs, jsonschema2pojo shall make use of command line parameter: --target-version 1.11 
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/AdditionalAttributeType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/AdditionalAttributeType.java
@@ -3,7 +3,6 @@ package gov.nasa.cumulus.metadata.umm.generated;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.processing.Generated;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -12,7 +11,6 @@ import com.google.gson.annotations.SerializedName;
  * A reference to an additional attribute in the parent collection. The attribute reference may contain a granule specific value that will override the value in the parent collection for this granule. An attribute with the  same name must exist in the parent collection.
  * 
  */
-@Generated("jsonschema2pojo")
 public class AdditionalAttributeType {
 
     /**

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/BoundaryType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/BoundaryType.java
@@ -3,7 +3,6 @@ package gov.nasa.cumulus.metadata.umm.generated;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.processing.Generated;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -12,7 +11,6 @@ import com.google.gson.annotations.SerializedName;
  * A boundary is set of points connected by straight lines representing a polygon on the earth. It takes a minimum of three points to make a boundary. Points must be specified in counter-clockwise order and closed (the first and last vertices are the same).
  * 
  */
-@Generated("jsonschema2pojo")
 public class BoundaryType {
 
     /**

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/BoundingRectangleType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/BoundingRectangleType.java
@@ -1,7 +1,6 @@
 
 package gov.nasa.cumulus.metadata.umm.generated;
 
-import javax.annotation.processing.Generated;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -10,7 +9,6 @@ import com.google.gson.annotations.SerializedName;
  * This entity holds the horizontal spatial coverage of a bounding box.
  * 
  */
-@Generated("jsonschema2pojo")
 public class BoundingRectangleType {
 
     /**

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/ExclusiveZoneType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/ExclusiveZoneType.java
@@ -3,7 +3,6 @@ package gov.nasa.cumulus.metadata.umm.generated;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.processing.Generated;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -12,7 +11,6 @@ import com.google.gson.annotations.SerializedName;
  * Contains the excluded boundaries from the GPolygon.
  * 
  */
-@Generated("jsonschema2pojo")
 public class ExclusiveZoneType {
 
     /**

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/GPolygonType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/GPolygonType.java
@@ -1,7 +1,6 @@
 
 package gov.nasa.cumulus.metadata.umm.generated;
 
-import javax.annotation.processing.Generated;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -10,7 +9,6 @@ import com.google.gson.annotations.SerializedName;
  * A GPolygon specifies an area on the earth represented by a main boundary with optional boundaries for regions excluded from the main boundary.
  * 
  */
-@Generated("jsonschema2pojo")
 public class GPolygonType {
 
     /**

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/GeometryType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/GeometryType.java
@@ -3,7 +3,6 @@ package gov.nasa.cumulus.metadata.umm.generated;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
-import javax.annotation.processing.Generated;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -12,7 +11,6 @@ import com.google.gson.annotations.SerializedName;
  * This entity holds the geometry representing the spatial coverage information of a granule.
  * 
  */
-@Generated("jsonschema2pojo")
 public class GeometryType {
 
     /**

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/HorizontalSpatialDomainType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/HorizontalSpatialDomainType.java
@@ -1,7 +1,6 @@
 
 package gov.nasa.cumulus.metadata.umm.generated;
 
-import javax.annotation.processing.Generated;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -10,7 +9,6 @@ import com.google.gson.annotations.SerializedName;
  * Information about a granule with horizontal spatial coverage.
  * 
  */
-@Generated("jsonschema2pojo")
 public class HorizontalSpatialDomainType {
 
     /**

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/LineType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/LineType.java
@@ -3,7 +3,6 @@ package gov.nasa.cumulus.metadata.umm.generated;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.processing.Generated;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -12,7 +11,6 @@ import com.google.gson.annotations.SerializedName;
  * This entity holds the horizontal spatial coverage of a line. A line area contains at lease two points.
  * 
  */
-@Generated("jsonschema2pojo")
 public class LineType {
 
     /**

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/OrbitType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/OrbitType.java
@@ -3,7 +3,6 @@ package gov.nasa.cumulus.metadata.umm.generated;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.processing.Generated;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -12,7 +11,6 @@ import com.google.gson.annotations.SerializedName;
  * This entity stores orbital coverage information of the granule. This coverage is an alternative way of expressing granule spatial coverage. This information supports orbital backtrack searching on a granule.
  * 
  */
-@Generated("jsonschema2pojo")
 public class OrbitType {
 
     /**
@@ -206,7 +204,6 @@ public class OrbitType {
      * Orbit start and end direction. A for ascending orbit and D for descending.
      * 
      */
-    @Generated("jsonschema2pojo")
     public enum OrbitDirectionTypeEnum {
 
         @SerializedName("A")

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/PointType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/PointType.java
@@ -1,7 +1,6 @@
 
 package gov.nasa.cumulus.metadata.umm.generated;
 
-import javax.annotation.processing.Generated;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -10,7 +9,6 @@ import com.google.gson.annotations.SerializedName;
  * The longitude and latitude values of a spatially referenced point in degrees.
  * 
  */
-@Generated("jsonschema2pojo")
 public class PointType {
 
     /**

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/RelatedUrlType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/RelatedUrlType.java
@@ -3,7 +3,6 @@ package gov.nasa.cumulus.metadata.umm.generated;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.processing.Generated;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -12,7 +11,6 @@ import com.google.gson.annotations.SerializedName;
  * This entity holds all types of online URL associated with the granule such as guide document or ordering site etc.
  * 
  */
-@Generated("jsonschema2pojo")
 public class RelatedUrlType {
 
     /**
@@ -257,7 +255,6 @@ public class RelatedUrlType {
      * The unit of the file size.
      * 
      */
-    @Generated("jsonschema2pojo")
     public enum FileSizeUnitEnum {
 
         @SerializedName("KB")
@@ -305,7 +302,6 @@ public class RelatedUrlType {
 
     }
 
-    @Generated("jsonschema2pojo")
     public enum MimeTypeEnum {
 
         @SerializedName("application/json")
@@ -397,7 +393,6 @@ public class RelatedUrlType {
 
     }
 
-    @Generated("jsonschema2pojo")
     public enum RelatedUrlSubTypeEnum {
 
         @SerializedName("MOBILE APP")
@@ -569,7 +564,6 @@ public class RelatedUrlType {
 
     }
 
-    @Generated("jsonschema2pojo")
     public enum RelatedUrlTypeEnum {
 
         @SerializedName("DOWNLOAD SOFTWARE")

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/SpatialExtentType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/SpatialExtentType.java
@@ -3,7 +3,6 @@ package gov.nasa.cumulus.metadata.umm.generated;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
-import javax.annotation.processing.Generated;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -12,7 +11,6 @@ import com.google.gson.annotations.SerializedName;
  * This class contains attributes which describe the spatial extent of a granule. Spatial Extent includes any or all of Granule Localities, Horizontal Spatial Domain, and Vertical Spatial Domain.
  * 
  */
-@Generated("jsonschema2pojo")
 public class SpatialExtentType {
 
     /**

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/TrackPassTileType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/TrackPassTileType.java
@@ -3,7 +3,6 @@ package gov.nasa.cumulus.metadata.umm.generated;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.processing.Generated;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -12,7 +11,6 @@ import com.google.gson.annotations.SerializedName;
  * This element stores a track pass and its tile information. It will allow a user to search by pass number and their tiles that are contained with in a cycle number.  While trying to keep this generic for all to use, this comes from a SWOT requirement where a pass represents a 1/2 orbit. This element will then hold a list of 1/2 orbits and their tiles that together represent the granules spatial extent.
  * 
  */
-@Generated("jsonschema2pojo")
 public class TrackPassTileType {
 
     /**

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/TrackType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/TrackType.java
@@ -3,7 +3,6 @@ package gov.nasa.cumulus.metadata.umm.generated;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.processing.Generated;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -12,7 +11,6 @@ import com.google.gson.annotations.SerializedName;
  * This element stores track information of the granule. Track information is used to allow a user to search for granules whose spatial extent is based on an orbital cycle, pass, and tile mapping. Though it is derived from the SWOT mission requirements, it is intended that this element type be generic enough so that other missions can make use of it. While track information is a type of spatial domain, it is expected that the metadata provider will provide geometry information that matches the spatial extent of the track information.
  * 
  */
-@Generated("jsonschema2pojo")
 public class TrackType {
 
     /**

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/VerticalSpatialDomainType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/VerticalSpatialDomainType.java
@@ -3,7 +3,6 @@ package gov.nasa.cumulus.metadata.umm.generated;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.processing.Generated;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -12,7 +11,6 @@ import com.google.gson.annotations.SerializedName;
  * This entity contains the type and value for the granule's vertical spatial domain.
  * 
  */
-@Generated("jsonschema2pojo")
 public class VerticalSpatialDomainType {
 
     @SerializedName("Type")
@@ -179,7 +177,6 @@ public class VerticalSpatialDomainType {
      * Describes the unit of the vertical extent value.
      * 
      */
-    @Generated("jsonschema2pojo")
     public enum Unit {
 
         @SerializedName("Fathoms")
@@ -235,7 +232,6 @@ public class VerticalSpatialDomainType {
 
     }
 
-    @Generated("jsonschema2pojo")
     public enum VerticalSpatialDomainTypeEnum {
 
         @SerializedName("Atmosphere Layer")


### PR DESCRIPTION
Github Issue: PODAAC-5878

### Description

update MetadataAggregator to java 11, cumulus-adapter-java 2.0.0. cma 2.0.3

### Overview of work done

Further improve the code by regenerating the UMMG pojos (ummg1.6.5 schema) using --target-version 1.11  flag
so the POJOs will be java 11 compatible.

### Overview of verification done
* unit test cases executed with no error.  Unit test code can be executed within IntelliJ IDE
* Integration tested with MODIS_A JPL 

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [] Updated changelog
* [x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_