### PR TITLE
fix footprint and bbx always appears together issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- **PODAAC-5857**
+  - Fixed the issue so footprint and bbx do not always appear together while isoXmlSpatial is configured to footprint only
+  - remove request.close() statement in CMRLambdaRestClient so the response could be pulled out and logged properly instead of always logging apache chunk read error due to the http channel was closed.
+  - adding more parameters to Jsonschema2pojo plugin to generate proper pojo from ummg schema
 ### Security
 
 ## [8.5.0]

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,9 @@
           <targetPackage>gov.nasa.cumulus.metadata.umm.generated</targetPackage>
           <sourceType>jsonschema</sourceType>
           <annotationStyle>GSON</annotationStyle>
-          <includeConstructors>true</includeConstructors>
+          <includeConstructors>false</includeConstructors>
+          <targetVersion>11</targetVersion>
+          <includeGeneratedAnnotation>false</includeGeneratedAnnotation>
           <formatDateTimes>true</formatDateTimes>
           <formatDates>true</formatDates>
           <formatDateTimes>true</formatDateTimes>

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/CMRLambdaRestClient.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/CMRLambdaRestClient.java
@@ -76,7 +76,6 @@ public class CMRLambdaRestClient extends CMRRestClient {
         this.echoHost = cmrHost;
         URIBuilder uriBuilder = new URIBuilder(tknHost);
         this.tokenHost = uriBuilder.setPath(uriBuilder.getPath() + "/gettoken").build().normalize().toString();
-        AdapterLogger.LogInfo(this.className + " final token url:" + this.tokenHost);
         this.validHost = this.tokenHost.replaceAll("gettoken", "validate");
         this.region = region;
         this.tknBucket = tknBucket;
@@ -105,7 +104,6 @@ public class CMRLambdaRestClient extends CMRRestClient {
         JSONObject jsonTkn = readToken();
         long fileTime = getTokenStartTime(jsonTkn);
         if (jsonTkn == null || sessionExpired(fileTime, runTime)) {
-            AdapterLogger.LogDebug(this.className + " Generating new NAMS token...");
             try {
                 this.token = buildToken(runTime);
             } catch (Exception e) {
@@ -113,7 +111,6 @@ public class CMRLambdaRestClient extends CMRRestClient {
                 throw new IOException("Could not retrieve token..." + e);
             }
         } else {
-            AdapterLogger.LogDebug(this.className + " Session active, using saved token");
             this.token = (String) jsonTkn.get("token");
         }
         return this.token;
@@ -261,7 +258,6 @@ public class CMRLambdaRestClient extends CMRRestClient {
         }
         String localTokenFilePath = s3Utils.download(this.region, this.tknBucket, this.tknFilePath,
                 Paths.get(this.workingDir, "token.json").toString());
-        AdapterLogger.LogInfo(this.className + " downloaded token file to local:" + localTokenFilePath);
         JSONObject json = null;
         try (FileReader reader = new FileReader(String.valueOf(localTokenFilePath))) {
             json = (JSONObject) parser.parse(reader);
@@ -278,7 +274,6 @@ public class CMRLambdaRestClient extends CMRRestClient {
         JSONObject json = new JSONObject();
         json.put("authTime", timeStamp);
         json.put("token", token);
-        AdapterLogger.LogDebug(this.className + " Writing new token to file");
         Path localTknFilePath = Files.write(Paths.get(this.workingDir, "token.json"),
                 json.toString().getBytes());
         s3Utils.upload(region, this.tknBucket, this.tknFilePath, new File(localTknFilePath.toString()) );
@@ -302,7 +297,6 @@ public class CMRLambdaRestClient extends CMRRestClient {
         request.setHeader("Content-Type", content_type);
         // Send the request
         HttpResponse response = httpClient.execute(request);
-        request.releaseConnection();
         return response;
     }
 
@@ -314,7 +308,6 @@ public class CMRLambdaRestClient extends CMRRestClient {
             String validateUMMGUri = uriBuilder.setPath(uriBuilder.getPath() + "/ingest/providers/"
                     + provider +"/validate/granule/" + granuleId)
                     .build().normalize().toString();
-            AdapterLogger.LogDebug("validateUri:" + validateUMMGUri);
             HttpEntity httpEntity = new StringEntity(strUMMG, "utf-8");
             HttpResponse httpResponse = send(validateUMMGUri, httpEntity);
             return httpResponse;

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/CMRRestClient.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/CMRRestClient.java
@@ -191,8 +191,6 @@ public class CMRRestClient {
         } else {
             logHttpResponse(response, HttpOp.SEND);
         }
-        // close the connection
-        request.releaseConnection();
     }
 
     public void closeScrollSession(String scrollJson) throws IOException {

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/IsoGranule.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/IsoGranule.java
@@ -20,7 +20,7 @@ public class IsoGranule extends UMMGranule {
     private List<String> inputGranules;
     private String PGEVersionClass;
 
-    private IsoType isoType;
+
 
     public IsoGranule() {
         this.identifiers = new HashMap<>();
@@ -129,13 +129,5 @@ public class IsoGranule extends UMMGranule {
 
     public void setPGEVersionClass(String PGEVersionClass) {
         this.PGEVersionClass = PGEVersionClass;
-    }
-
-    public IsoType getIsoType() {
-        return isoType;
-    }
-
-    public void setIsoType(IsoType isoType) {
-        this.isoType = isoType;
     }
 }

--- a/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/aggregator/MetadataFilesToEcho.java
@@ -10,7 +10,6 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
 import javax.xml.bind.DatatypeConverter;
 import javax.xml.parsers.DocumentBuilder;
@@ -324,12 +323,12 @@ public class MetadataFilesToEcho {
         // if we get here, we have the bare minimum fields already populated,
         // so try and parse the rest of the granule metadata...
         try {
+			((IsoGranule) this.granule).setIsoType(isoType);
             if (isoType == IsoType.MENDS) {
                 AdapterLogger.LogInfo("Found MENDS file");
                 readIsoMendsMetadataFile(s3Location, doc, xpath);
             } else if (isoType == IsoType.SMAP) {
                 AdapterLogger.LogInfo("Found SMAP file");
-				((IsoGranule) this.granule).setIsoType(isoType);
                 readIsoSmapMetadataFile(s3Location, doc, xpath);
             } else {
                 AdapterLogger.LogWarning(isoType.name() + " didn't match any expected ISO type, skipping optional " +
@@ -486,7 +485,6 @@ public class MetadataFilesToEcho {
 
 		((IsoGranule) granule).setOrbit(MENDsISOXmlUtiils.extractXPathValueSwallowException(doc, xpath, IsoMendsXPath.ORBIT, "IsoMendsXPath.ORBIT"));
 		((IsoGranule) granule).setSwotTrack(MENDsISOXmlUtiils.extractXPathValueSwallowException(doc, xpath, IsoMendsXPath.SWOT_TRACK, "IsoMendsXPath.SWOT_TRACK"));
-
 		Source source = new Source();
 		source.setSourceShortName(MENDsISOXmlUtiils.extractXPathValueSwallowException(doc, xpath, IsoMendsXPath.PLATFORM, "IsoMendsXPath.PLATFORM"));
 
@@ -511,7 +509,7 @@ public class MetadataFilesToEcho {
 		String  cyclePassTileSceneStr =StringUtils.trim(MENDsISOXmlUtiils.extractXPathValueSwallowException(doc, xpath, IsoMendsXPath.CYCLE_PASS_TILE_SCENE, "IsoMendsXPath.CYCLE_PASS_TILE_SCENE"));
 		if(!StringUtils.isBlank(cyclePassTileSceneStr)) {
 			try {
-				createIsoCyclePassTile(cyclePassTileSceneStr);
+				granule = createIsoCyclePassTile(cyclePassTileSceneStr);
 			} catch (Exception e) {
 				// Since TrackType which contains Cycle Pass Tile and Scenes is not a required field
 				// we catch exception with printStackTrace to know the exact line throwing error

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/RelatedUrlType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/RelatedUrlType.java
@@ -9,22 +9,22 @@ import com.google.gson.annotations.SerializedName;
 
 /**
  * This entity holds all types of online URL associated with the granule such as guide document or ordering site etc.
- * 
+ *
  */
 public class RelatedUrlType {
 
     /**
      * The URL for the relevant resource.
      * (Required)
-     * 
+     *
      */
     @SerializedName("URL")
     @Expose
     private String url;
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @SerializedName("Type")
     @Expose
@@ -34,14 +34,14 @@ public class RelatedUrlType {
     private RelatedUrlType.RelatedUrlSubTypeEnum subtype;
     /**
      * Description of the web page at this URL.
-     * 
+     *
      */
     @SerializedName("Description")
     @Expose
     private String description;
     /**
      * The format that granule data confirms to. While the value is listed as open to any text, CMR requires that it confirm to one of the values on the GranuleDataFormat values in the Keyword Management System: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/GranuleDataFormat
-     * 
+     *
      */
     @SerializedName("Format")
     @Expose
@@ -51,14 +51,14 @@ public class RelatedUrlType {
     private RelatedUrlType.MimeTypeEnum mimeType;
     /**
      * The size of the resource.
-     * 
+     *
      */
     @SerializedName("Size")
     @Expose
     private Double size;
     /**
      * The unit of the file size.
-     * 
+     *
      */
     @SerializedName("SizeUnit")
     @Expose
@@ -67,7 +67,7 @@ public class RelatedUrlType {
     /**
      * The URL for the relevant resource.
      * (Required)
-     * 
+     *
      */
     public String getUrl() {
         return url;
@@ -76,25 +76,25 @@ public class RelatedUrlType {
     /**
      * The URL for the relevant resource.
      * (Required)
-     * 
+     *
      */
     public void setUrl(String url) {
         this.url = url;
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     public RelatedUrlType.RelatedUrlTypeEnum getType() {
         return type;
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     public void setType(RelatedUrlType.RelatedUrlTypeEnum type) {
         this.type = type;
@@ -110,7 +110,7 @@ public class RelatedUrlType {
 
     /**
      * Description of the web page at this URL.
-     * 
+     *
      */
     public String getDescription() {
         return description;
@@ -118,7 +118,7 @@ public class RelatedUrlType {
 
     /**
      * Description of the web page at this URL.
-     * 
+     *
      */
     public void setDescription(String description) {
         this.description = description;
@@ -126,7 +126,7 @@ public class RelatedUrlType {
 
     /**
      * The format that granule data confirms to. While the value is listed as open to any text, CMR requires that it confirm to one of the values on the GranuleDataFormat values in the Keyword Management System: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/GranuleDataFormat
-     * 
+     *
      */
     public String getFormat() {
         return format;
@@ -134,7 +134,7 @@ public class RelatedUrlType {
 
     /**
      * The format that granule data confirms to. While the value is listed as open to any text, CMR requires that it confirm to one of the values on the GranuleDataFormat values in the Keyword Management System: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/GranuleDataFormat
-     * 
+     *
      */
     public void setFormat(String format) {
         this.format = format;
@@ -150,7 +150,7 @@ public class RelatedUrlType {
 
     /**
      * The size of the resource.
-     * 
+     *
      */
     public Double getSize() {
         return size;
@@ -158,7 +158,7 @@ public class RelatedUrlType {
 
     /**
      * The size of the resource.
-     * 
+     *
      */
     public void setSize(Double size) {
         this.size = size;
@@ -166,7 +166,7 @@ public class RelatedUrlType {
 
     /**
      * The unit of the file size.
-     * 
+     *
      */
     public RelatedUrlType.FileSizeUnitEnum getSizeUnit() {
         return sizeUnit;
@@ -174,7 +174,7 @@ public class RelatedUrlType {
 
     /**
      * The unit of the file size.
-     * 
+     *
      */
     public void setSizeUnit(RelatedUrlType.FileSizeUnitEnum sizeUnit) {
         this.sizeUnit = sizeUnit;
@@ -253,7 +253,7 @@ public class RelatedUrlType {
 
     /**
      * The unit of the file size.
-     * 
+     *
      */
     public enum FileSizeUnitEnum {
 

--- a/src/main/java/gov/nasa/cumulus/metadata/umm/generated/TrackType.java
+++ b/src/main/java/gov/nasa/cumulus/metadata/umm/generated/TrackType.java
@@ -9,21 +9,21 @@ import com.google.gson.annotations.SerializedName;
 
 /**
  * This element stores track information of the granule. Track information is used to allow a user to search for granules whose spatial extent is based on an orbital cycle, pass, and tile mapping. Though it is derived from the SWOT mission requirements, it is intended that this element type be generic enough so that other missions can make use of it. While track information is a type of spatial domain, it is expected that the metadata provider will provide geometry information that matches the spatial extent of the track information.
- * 
+ *
  */
 public class TrackType {
 
     /**
      * An integer that represents a specific set of orbital spatial extents defined by passes and tiles. Though intended to be generic, this comes from a SWOT mission requirement where each cycle represents a set of 1/2 orbits. Each 1/2 orbit is called a 'pass'. During science mode, a cycle represents 21 days of 14 full orbits or 588 passes.
      * (Required)
-     * 
+     *
      */
     @SerializedName("Cycle")
     @Expose
     private Integer cycle;
     /**
      * A pass number identifies a subset of a granule's spatial extent. This element holds a list of pass numbers and their tiles that exist in the granule. It will allow a user to search by pass number and its tiles that are contained with in a cycle number.  While trying to keep this generic for all to use, this comes from a SWOT requirement where a pass represents a 1/2 orbit. This element will then hold a list of 1/2 orbits and their tiles that together represent the granule's spatial extent.
-     * 
+     *
      */
     @SerializedName("Passes")
     @Expose
@@ -32,7 +32,7 @@ public class TrackType {
     /**
      * An integer that represents a specific set of orbital spatial extents defined by passes and tiles. Though intended to be generic, this comes from a SWOT mission requirement where each cycle represents a set of 1/2 orbits. Each 1/2 orbit is called a 'pass'. During science mode, a cycle represents 21 days of 14 full orbits or 588 passes.
      * (Required)
-     * 
+     *
      */
     public Integer getCycle() {
         return cycle;
@@ -41,7 +41,7 @@ public class TrackType {
     /**
      * An integer that represents a specific set of orbital spatial extents defined by passes and tiles. Though intended to be generic, this comes from a SWOT mission requirement where each cycle represents a set of 1/2 orbits. Each 1/2 orbit is called a 'pass'. During science mode, a cycle represents 21 days of 14 full orbits or 588 passes.
      * (Required)
-     * 
+     *
      */
     public void setCycle(Integer cycle) {
         this.cycle = cycle;
@@ -49,7 +49,7 @@ public class TrackType {
 
     /**
      * A pass number identifies a subset of a granule's spatial extent. This element holds a list of pass numbers and their tiles that exist in the granule. It will allow a user to search by pass number and its tiles that are contained with in a cycle number.  While trying to keep this generic for all to use, this comes from a SWOT requirement where a pass represents a 1/2 orbit. This element will then hold a list of 1/2 orbits and their tiles that together represent the granule's spatial extent.
-     * 
+     *
      */
     public List<TrackPassTileType> getPasses() {
         return passes;
@@ -57,7 +57,7 @@ public class TrackType {
 
     /**
      * A pass number identifies a subset of a granule's spatial extent. This element holds a list of pass numbers and their tiles that exist in the granule. It will allow a user to search by pass number and its tiles that are contained with in a cycle number.  While trying to keep this generic for all to use, this comes from a SWOT requirement where a pass represents a 1/2 orbit. This element will then hold a list of 1/2 orbits and their tiles that together represent the granule's spatial extent.
-     * 
+     *
      */
     public void setPasses(List<TrackPassTileType> passes) {
         this.passes = passes;

--- a/src/main/java/gov/nasa/podaac/inventory/model/Granule.java
+++ b/src/main/java/gov/nasa/podaac/inventory/model/Granule.java
@@ -4,6 +4,7 @@
 package gov.nasa.podaac.inventory.model;
 
 
+import gov.nasa.cumulus.metadata.aggregator.IsoType;
 import gov.nasa.podaac.inventory.api.Constant.GranuleStatus;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -63,6 +64,8 @@ public class Granule {
     private Set<GranuleMetaHistory> metaHistorySet = new HashSet<GranuleMetaHistory>();
     private Set<GranuleContact> granuleContactSet = new HashSet<GranuleContact>();
 	private Dataset dataset;
+
+	private IsoType isoType;
 	
 	private static Log log = LogFactory.getLog(Granule.class);
 
@@ -847,7 +850,14 @@ public class Granule {
 			}
 		}
 	}
-	
+
+	public IsoType getIsoType() {
+		return isoType;
+	}
+
+	public void setIsoType(IsoType isoType) {
+		this.isoType = isoType;
+	}
 	
     
 }


### PR DESCRIPTION
Github Issue: PODAAC-5857

### Description

Making CMR validation error message more descriptive

### Overview of work done

* Fixed the issue so footprint and bbx do not always appear together while isoXmlSpatial is configured to footprint only
* remove request.close() statement in CMRLambdaRestClient so the response could be pulled out and logged properly instead of always logging apache chunk read error due to the http channel was closed.
* adding more parameters to Jsonschema2pojo plugin to generate proper pojo from ummg schema
* Also , tested the issue we had with SWOT_L2_HR_RiverSP_1_0 before where isoXmlSpatial was set to bbox only and set to footprint only.  After setting to footprint only, we always see both footprint and bbx.  It is also fixed by this change

### Overview of verification done
* Unit test all cases no error
* integration tested SWOT_L2_LR_SSH_2.0

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [x] Updated changelog
* [x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_